### PR TITLE
feat: モニタリング差分入力UI機能を追加

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import { LoginScreen } from './components/auth';
 import { useAuth } from './contexts/AuthContext';
 import { PrintPreview } from './components/careplan';
 import { saveAssessment, listAssessments, getAssessment, deleteAssessment, AssessmentDocument, saveCarePlan } from './services/firebase';
-import { MonitoringForm } from './components/monitoring';
+import { MonitoringDiffView } from './components/monitoring';
 import { SupportRecordForm, SupportRecordList } from './components/records';
 import { HospitalAdmissionSheetView } from './components/documents';
 import { generateHospitalAdmissionSheet, UserBasicInfo, CareManagerInfo } from './utils/hospitalAdmissionSheet';
@@ -866,7 +866,7 @@ export default function App() {
                   月次モニタリング・目標達成状況の評価
                 </p>
               </div>
-              <MonitoringForm
+              <MonitoringDiffView
                 userId={user?.uid || MOCK_USER.id}
                 carePlanId={plan.id}
                 goals={plan.shortTermGoals}

--- a/components/monitoring/GoalEvaluationDiff.tsx
+++ b/components/monitoring/GoalEvaluationDiff.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import type { GoalEvaluationStatus } from '../../types';
+
+interface PreviousEvaluation {
+  status: GoalEvaluationStatus;
+  observation: string;
+}
+
+interface GoalEvaluationDiffProps {
+  goalContent: string;
+  status: GoalEvaluationStatus;
+  observation: string;
+  previousEvaluation?: PreviousEvaluation;
+  onStatusChange: (status: GoalEvaluationStatus) => void;
+  onObservationChange: (observation: string) => void;
+  showDiff?: boolean;
+}
+
+const statusOptions: { value: GoalEvaluationStatus; label: string; color: string; order: number }[] = [
+  { value: 'achieved', label: '達成', color: 'bg-green-100 text-green-800 border-green-300', order: 4 },
+  { value: 'progressing', label: '改善傾向', color: 'bg-blue-100 text-blue-800 border-blue-300', order: 3 },
+  { value: 'unchanged', label: '変化なし', color: 'bg-gray-100 text-gray-800 border-gray-300', order: 2 },
+  { value: 'declined', label: '悪化傾向', color: 'bg-red-100 text-red-800 border-red-300', order: 1 },
+  { value: 'not_evaluated', label: '未評価', color: 'bg-yellow-100 text-yellow-800 border-yellow-300', order: 0 },
+];
+
+const getStatusOption = (status: GoalEvaluationStatus) =>
+  statusOptions.find((o) => o.value === status) || statusOptions[4];
+
+type StatusChange = 'improved' | 'declined' | 'unchanged' | 'new';
+
+const getStatusChange = (
+  current: GoalEvaluationStatus,
+  previous?: GoalEvaluationStatus
+): StatusChange => {
+  if (!previous || previous === 'not_evaluated') return 'new';
+
+  const currentOrder = getStatusOption(current).order;
+  const previousOrder = getStatusOption(previous).order;
+
+  if (currentOrder > previousOrder) return 'improved';
+  if (currentOrder < previousOrder) return 'declined';
+  return 'unchanged';
+};
+
+const statusChangeDisplay: Record<StatusChange, { icon: string; color: string; label: string }> = {
+  improved: { icon: '↑', color: 'text-green-600 bg-green-50', label: '改善' },
+  declined: { icon: '↓', color: 'text-red-600 bg-red-50', label: '悪化' },
+  unchanged: { icon: '→', color: 'text-gray-500 bg-gray-50', label: '継続' },
+  new: { icon: '✦', color: 'text-blue-600 bg-blue-50', label: '新規' },
+};
+
+export const GoalEvaluationDiff: React.FC<GoalEvaluationDiffProps> = ({
+  goalContent,
+  status,
+  observation,
+  previousEvaluation,
+  onStatusChange,
+  onObservationChange,
+  showDiff = true,
+}) => {
+  const hasPrevious = previousEvaluation !== undefined;
+  const statusChange = showDiff
+    ? getStatusChange(status, previousEvaluation?.status)
+    : 'new';
+  const changeDisplay = statusChangeDisplay[statusChange];
+
+  const handleCopyPreviousObservation = () => {
+    if (previousEvaluation?.observation) {
+      onObservationChange(previousEvaluation.observation);
+    }
+  };
+
+  return (
+    <div className="border rounded-lg p-4 bg-white">
+      {/* 目標内容とステータス変化表示 */}
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div className="flex-1">
+          <span className="text-sm text-gray-500">目標:</span>
+          <p className="text-gray-900 font-medium">{goalContent}</p>
+        </div>
+        {showDiff && hasPrevious && (
+          <span
+            className={`flex-shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium ${changeDisplay.color}`}
+          >
+            <span className="font-bold">{changeDisplay.icon}</span>
+            {changeDisplay.label}
+          </span>
+        )}
+      </div>
+
+      {/* 評価ステータス選択 */}
+      <div className="mb-3">
+        <label className="block text-sm text-gray-500 mb-2">評価:</label>
+        <div className="flex flex-wrap gap-2">
+          {statusOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onStatusChange(option.value)}
+              className={`px-3 py-1 rounded-full text-sm border transition-all ${
+                status === option.value
+                  ? `${option.color} ring-2 ring-offset-1 ring-blue-500`
+                  : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 前回ステータスの表示 */}
+        {showDiff && hasPrevious && previousEvaluation.status !== 'not_evaluated' && (
+          <div className="mt-2 text-xs text-gray-500">
+            📋 前回評価: {getStatusOption(previousEvaluation.status).label}
+          </div>
+        )}
+      </div>
+
+      {/* 観察内容 */}
+      <div>
+        <label className="block text-sm text-gray-500 mb-1">観察内容・変化の詳細:</label>
+        <textarea
+          value={observation}
+          onChange={(e) => onObservationChange(e.target.value)}
+          placeholder="具体的な状態や変化を記録..."
+          className={`w-full px-3 py-2 border rounded-md text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+            showDiff && hasPrevious && observation !== previousEvaluation?.observation
+              ? 'border-amber-400 bg-amber-50'
+              : 'border-gray-300'
+          }`}
+          rows={2}
+        />
+
+        {/* 前回観察内容の表示 */}
+        {showDiff && hasPrevious && previousEvaluation.observation && (
+          <div className="mt-2 flex items-start gap-2 p-2 bg-gray-50 rounded-md border border-gray-200">
+            <span className="flex-shrink-0 text-gray-500 text-xs mt-0.5">📋 前回:</span>
+            <p className="flex-1 text-sm text-gray-600 whitespace-pre-wrap break-words">
+              {previousEvaluation.observation}
+            </p>
+            <button
+              type="button"
+              onClick={handleCopyPreviousObservation}
+              className="flex-shrink-0 px-2 py-1 text-xs bg-blue-100 text-blue-700 rounded hover:bg-blue-200 transition-colors"
+            >
+              コピー
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GoalEvaluationDiff;

--- a/components/monitoring/MonitoringCompareField.tsx
+++ b/components/monitoring/MonitoringCompareField.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+
+type FieldType = 'text' | 'textarea' | 'select';
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface MonitoringCompareFieldProps {
+  label: string;
+  fieldType: FieldType;
+  currentValue: string;
+  previousValue?: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  selectOptions?: SelectOption[];
+  rows?: number;
+  showDiff?: boolean;
+}
+
+export const MonitoringCompareField: React.FC<MonitoringCompareFieldProps> = ({
+  label,
+  fieldType,
+  currentValue,
+  previousValue,
+  onChange,
+  placeholder,
+  selectOptions = [],
+  rows = 3,
+  showDiff = true,
+}) => {
+  const hasPrevious = previousValue !== undefined && previousValue !== '';
+  const hasChanged = hasPrevious && currentValue !== previousValue;
+
+  const handleCopyPrevious = () => {
+    if (previousValue) {
+      onChange(previousValue);
+    }
+  };
+
+  const getDisplayValue = (value: string): string => {
+    if (fieldType === 'select' && selectOptions.length > 0) {
+      const option = selectOptions.find((o) => o.value === value);
+      return option?.label || value;
+    }
+    return value;
+  };
+
+  const renderInput = () => {
+    const baseClassName =
+      'w-full px-3 py-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+    const highlightClassName = hasChanged
+      ? 'border-amber-400 bg-amber-50'
+      : 'border-gray-300';
+
+    switch (fieldType) {
+      case 'textarea':
+        return (
+          <textarea
+            value={currentValue}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder}
+            className={`${baseClassName} ${highlightClassName} resize-none`}
+            rows={rows}
+          />
+        );
+
+      case 'select':
+        return (
+          <select
+            value={currentValue}
+            onChange={(e) => onChange(e.target.value)}
+            className={`${baseClassName} ${highlightClassName}`}
+          >
+            {selectOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        );
+
+      default:
+        return (
+          <input
+            type="text"
+            value={currentValue}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder}
+            className={`${baseClassName} ${highlightClassName}`}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="block text-sm font-medium text-gray-700">
+          {label}
+        </label>
+        {hasChanged && showDiff && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
+            ⚡ 変更あり
+          </span>
+        )}
+      </div>
+
+      {renderInput()}
+
+      {/* 前回値の表示 */}
+      {hasPrevious && showDiff && (
+        <div className="flex items-start gap-2 p-2 bg-gray-50 rounded-md border border-gray-200">
+          <span className="flex-shrink-0 text-gray-500 text-xs mt-0.5">📋 前回:</span>
+          <p className="flex-1 text-sm text-gray-600 whitespace-pre-wrap break-words">
+            {getDisplayValue(previousValue!)}
+          </p>
+          <button
+            type="button"
+            onClick={handleCopyPrevious}
+            className="flex-shrink-0 px-2 py-1 text-xs bg-blue-100 text-blue-700 rounded hover:bg-blue-200 transition-colors"
+          >
+            コピー
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MonitoringCompareField;

--- a/components/monitoring/MonitoringDiffView.tsx
+++ b/components/monitoring/MonitoringDiffView.tsx
@@ -1,0 +1,567 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Timestamp } from 'firebase/firestore';
+import { GoalEvaluationDiff } from './GoalEvaluationDiff';
+import { MonitoringCompareField } from './MonitoringCompareField';
+import {
+  saveMonitoringRecord,
+  getMonitoringRecord,
+  listMonitoringRecordsByCarePlan,
+  type MonitoringRecordDocument,
+} from '../../services/firebase';
+import type { GoalEvaluationStatus, CareGoal } from '../../types';
+
+interface GoalEvaluationData {
+  goalId: string;
+  goalContent: string;
+  status: GoalEvaluationStatus;
+  observation: string;
+}
+
+interface ServiceUsageData {
+  serviceType: string;
+  provider: string;
+  plannedFrequency: string;
+  actualUsage: string;
+  remarks: string;
+}
+
+interface MonitoringDiffViewProps {
+  userId: string;
+  carePlanId: string;
+  goals: CareGoal[];
+  existingRecordId?: string;
+  onSave?: (recordId: string) => void;
+  onCancel?: () => void;
+}
+
+const visitMethodOptions = [
+  { value: 'home_visit', label: '居宅訪問' },
+  { value: 'online', label: 'オンライン' },
+  { value: 'phone', label: '電話' },
+] as const;
+
+export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
+  userId,
+  carePlanId,
+  goals,
+  existingRecordId,
+  onSave,
+  onCancel,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [diffMode, setDiffMode] = useState(true);
+  const [previousRecord, setPreviousRecord] = useState<MonitoringRecordDocument | null>(null);
+
+  // フォームデータ
+  const [visitDate, setVisitDate] = useState(new Date().toISOString().split('T')[0]);
+  const [visitMethod, setVisitMethod] = useState<'home_visit' | 'online' | 'phone'>('home_visit');
+  const [goalEvaluations, setGoalEvaluations] = useState<GoalEvaluationData[]>([]);
+  const [overallCondition, setOverallCondition] = useState('');
+  const [healthChanges, setHealthChanges] = useState('');
+  const [livingConditionChanges, setLivingConditionChanges] = useState('');
+  const [serviceUsageRecords, setServiceUsageRecords] = useState<ServiceUsageData[]>([]);
+  const [serviceUsageSummary, setServiceUsageSummary] = useState('');
+  const [userOpinion, setUserOpinion] = useState('');
+  const [familyOpinion, setFamilyOpinion] = useState('');
+  const [needsPlanRevision, setNeedsPlanRevision] = useState(false);
+  const [revisionReason, setRevisionReason] = useState('');
+  const [nextActions, setNextActions] = useState('');
+  const [nextMonitoringDate, setNextMonitoringDate] = useState('');
+
+  // 前回記録から前回評価を取得するヘルパー
+  const getPreviousEvaluation = useCallback(
+    (goalId: string) => {
+      if (!previousRecord) return undefined;
+      return previousRecord.goalEvaluations.find((e) => e.goalId === goalId);
+    },
+    [previousRecord]
+  );
+
+  // 初期化・前回記録の取得
+  useEffect(() => {
+    const initializeForm = async () => {
+      setLoading(true);
+      try {
+        // 目標から評価データを初期化
+        const initialEvaluations = goals.map((goal) => ({
+          goalId: goal.id,
+          goalContent: goal.content,
+          status: 'not_evaluated' as GoalEvaluationStatus,
+          observation: '',
+        }));
+        setGoalEvaluations(initialEvaluations);
+
+        // 既存レコードがあれば読み込み（編集モード）
+        if (existingRecordId) {
+          const record = await getMonitoringRecord(userId, existingRecordId);
+          if (record) {
+            populateFormFromRecord(record);
+          }
+        }
+
+        // 前回記録を取得（差分表示用）
+        const previousRecords = await listMonitoringRecordsByCarePlan(userId, carePlanId, 2);
+        // 編集中のレコード以外で直近のものを取得
+        const latestPrevious = previousRecords.find(
+          (r) => r.id !== existingRecordId
+        );
+        if (latestPrevious) {
+          setPreviousRecord(latestPrevious);
+        }
+      } catch (error) {
+        console.error('Failed to initialize form:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    initializeForm();
+  }, [goals, existingRecordId, userId, carePlanId]);
+
+  const populateFormFromRecord = (record: MonitoringRecordDocument) => {
+    setVisitDate(record.visitDate.toDate().toISOString().split('T')[0]);
+    setVisitMethod(record.visitMethod);
+    setGoalEvaluations(record.goalEvaluations);
+    setOverallCondition(record.overallCondition);
+    setHealthChanges(record.healthChanges);
+    setLivingConditionChanges(record.livingConditionChanges);
+    setServiceUsageRecords(record.serviceUsageRecords);
+    setServiceUsageSummary(record.serviceUsageSummary);
+    setUserOpinion(record.userOpinion);
+    setFamilyOpinion(record.familyOpinion);
+    setNeedsPlanRevision(record.needsPlanRevision);
+    setRevisionReason(record.revisionReason);
+    setNextActions(record.nextActions);
+    if (record.nextMonitoringDate) {
+      setNextMonitoringDate(record.nextMonitoringDate.toDate().toISOString().split('T')[0]);
+    }
+  };
+
+  const handleGoalStatusChange = (goalId: string, status: GoalEvaluationStatus) => {
+    setGoalEvaluations((prev) =>
+      prev.map((e) => (e.goalId === goalId ? { ...e, status } : e))
+    );
+  };
+
+  const handleGoalObservationChange = (goalId: string, observation: string) => {
+    setGoalEvaluations((prev) =>
+      prev.map((e) => (e.goalId === goalId ? { ...e, observation } : e))
+    );
+  };
+
+  const addServiceUsage = () => {
+    setServiceUsageRecords((prev) => [
+      ...prev,
+      { serviceType: '', provider: '', plannedFrequency: '', actualUsage: '', remarks: '' },
+    ]);
+  };
+
+  const updateServiceUsage = (index: number, field: keyof ServiceUsageData, value: string) => {
+    setServiceUsageRecords((prev) =>
+      prev.map((record, i) => (i === index ? { ...record, [field]: value } : record))
+    );
+  };
+
+  const removeServiceUsage = (index: number) => {
+    setServiceUsageRecords((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  // 前回値をすべてコピー
+  const copyAllFromPrevious = () => {
+    if (!previousRecord) return;
+
+    setVisitMethod(previousRecord.visitMethod);
+    setOverallCondition(previousRecord.overallCondition);
+    setHealthChanges(previousRecord.healthChanges);
+    setLivingConditionChanges(previousRecord.livingConditionChanges);
+    setServiceUsageRecords([...previousRecord.serviceUsageRecords]);
+    setServiceUsageSummary(previousRecord.serviceUsageSummary);
+    setUserOpinion(previousRecord.userOpinion);
+    setFamilyOpinion(previousRecord.familyOpinion);
+    setNextActions(previousRecord.nextActions);
+
+    // 目標評価もコピー（マッチするもののみ）
+    setGoalEvaluations((prev) =>
+      prev.map((e) => {
+        const prevEval = previousRecord.goalEvaluations.find(
+          (pe) => pe.goalId === e.goalId
+        );
+        if (prevEval) {
+          return { ...e, status: prevEval.status, observation: prevEval.observation };
+        }
+        return e;
+      })
+    );
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const recordId = existingRecordId || `monitoring_${Date.now()}`;
+
+      const data: Omit<MonitoringRecordDocument, 'id' | 'createdAt' | 'updatedAt'> = {
+        carePlanId,
+        userId,
+        recordDate: Timestamp.now(),
+        visitDate: Timestamp.fromDate(new Date(visitDate)),
+        visitMethod,
+        goalEvaluations,
+        overallCondition,
+        healthChanges,
+        livingConditionChanges,
+        serviceUsageRecords,
+        serviceUsageSummary,
+        userOpinion,
+        familyOpinion,
+        needsPlanRevision,
+        revisionReason,
+        nextActions,
+        nextMonitoringDate: nextMonitoringDate
+          ? Timestamp.fromDate(new Date(nextMonitoringDate))
+          : null,
+        createdBy: userId,
+      };
+
+      await saveMonitoringRecord(userId, recordId, data);
+
+      if (onSave) {
+        onSave(recordId);
+      }
+    } catch (error) {
+      console.error('Failed to save monitoring record:', error);
+      alert('保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        <span className="ml-2 text-gray-600">読み込み中...</span>
+      </div>
+    );
+  }
+
+  const formatPreviousDate = () => {
+    if (!previousRecord) return '';
+    return previousRecord.visitDate.toDate().toLocaleDateString('ja-JP');
+  };
+
+  return (
+    <div className="space-y-6 p-4 max-w-4xl mx-auto">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <h2 className="text-xl font-bold text-gray-900">モニタリング記録</h2>
+        <div className="flex items-center gap-3">
+          {previousRecord && (
+            <>
+              <button
+                type="button"
+                onClick={() => setDiffMode(!diffMode)}
+                className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${
+                  diffMode
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                差分モード: {diffMode ? 'ON' : 'OFF'}
+              </button>
+              {diffMode && (
+                <button
+                  type="button"
+                  onClick={copyAllFromPrevious}
+                  className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-md hover:bg-green-700"
+                >
+                  前回値をすべてコピー
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* 前回記録情報 */}
+      {previousRecord && diffMode && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+          <p className="text-sm text-blue-800">
+            <span className="font-medium">▶ 前回記録:</span> {formatPreviousDate()}{' '}
+            ({visitMethodOptions.find((o) => o.value === previousRecord.visitMethod)?.label})
+          </p>
+        </div>
+      )}
+
+      {/* 訪問情報 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">訪問情報</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              モニタリング実施日
+            </label>
+            <input
+              type="date"
+              value={visitDate}
+              onChange={(e) => setVisitDate(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <MonitoringCompareField
+            label="実施方法"
+            fieldType="select"
+            currentValue={visitMethod}
+            previousValue={diffMode ? previousRecord?.visitMethod : undefined}
+            onChange={(v) => setVisitMethod(v as typeof visitMethod)}
+            selectOptions={visitMethodOptions.map((o) => ({ value: o.value, label: o.label }))}
+            showDiff={diffMode}
+          />
+        </div>
+      </section>
+
+      {/* 目標評価 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">目標の評価</h3>
+        {goalEvaluations.length === 0 ? (
+          <p className="text-gray-500 text-sm">評価対象の目標がありません</p>
+        ) : (
+          <div className="space-y-4">
+            {goalEvaluations.map((evaluation) => (
+              <GoalEvaluationDiff
+                key={evaluation.goalId}
+                goalContent={evaluation.goalContent}
+                status={evaluation.status}
+                observation={evaluation.observation}
+                previousEvaluation={diffMode ? getPreviousEvaluation(evaluation.goalId) : undefined}
+                onStatusChange={(status) => handleGoalStatusChange(evaluation.goalId, status)}
+                onObservationChange={(obs) => handleGoalObservationChange(evaluation.goalId, obs)}
+                showDiff={diffMode}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* 全体評価 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">全体評価</h3>
+        <div className="space-y-4">
+          <MonitoringCompareField
+            label="利用者の全体的な状態"
+            fieldType="textarea"
+            currentValue={overallCondition}
+            previousValue={diffMode ? previousRecord?.overallCondition : undefined}
+            onChange={setOverallCondition}
+            placeholder="全体的な状態を記入..."
+            rows={3}
+            showDiff={diffMode}
+          />
+          <MonitoringCompareField
+            label="健康状態の変化"
+            fieldType="textarea"
+            currentValue={healthChanges}
+            previousValue={diffMode ? previousRecord?.healthChanges : undefined}
+            onChange={setHealthChanges}
+            placeholder="前回からの健康状態の変化..."
+            rows={2}
+            showDiff={diffMode}
+          />
+          <MonitoringCompareField
+            label="生活状況の変化"
+            fieldType="textarea"
+            currentValue={livingConditionChanges}
+            previousValue={diffMode ? previousRecord?.livingConditionChanges : undefined}
+            onChange={setLivingConditionChanges}
+            placeholder="生活環境や日常生活の変化..."
+            rows={2}
+            showDiff={diffMode}
+          />
+        </div>
+      </section>
+
+      {/* サービス利用状況 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold text-gray-800">サービス利用状況</h3>
+          <button
+            type="button"
+            onClick={addServiceUsage}
+            className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            + サービス追加
+          </button>
+        </div>
+        {serviceUsageRecords.length > 0 && (
+          <div className="space-y-3 mb-4">
+            {serviceUsageRecords.map((record, index) => (
+              <div key={index} className="border rounded-lg p-3 bg-gray-50">
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-2 mb-2">
+                  <input
+                    type="text"
+                    value={record.serviceType}
+                    onChange={(e) => updateServiceUsage(index, 'serviceType', e.target.value)}
+                    placeholder="サービス種別"
+                    className="px-2 py-1 border border-gray-300 rounded text-sm"
+                  />
+                  <input
+                    type="text"
+                    value={record.provider}
+                    onChange={(e) => updateServiceUsage(index, 'provider', e.target.value)}
+                    placeholder="事業所名"
+                    className="px-2 py-1 border border-gray-300 rounded text-sm"
+                  />
+                  <input
+                    type="text"
+                    value={record.plannedFrequency}
+                    onChange={(e) => updateServiceUsage(index, 'plannedFrequency', e.target.value)}
+                    placeholder="計画頻度"
+                    className="px-2 py-1 border border-gray-300 rounded text-sm"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <input
+                    type="text"
+                    value={record.actualUsage}
+                    onChange={(e) => updateServiceUsage(index, 'actualUsage', e.target.value)}
+                    placeholder="実際の利用状況"
+                    className="px-2 py-1 border border-gray-300 rounded text-sm"
+                  />
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={record.remarks}
+                      onChange={(e) => updateServiceUsage(index, 'remarks', e.target.value)}
+                      placeholder="備考"
+                      className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeServiceUsage(index)}
+                      className="px-2 py-1 text-red-600 hover:bg-red-50 rounded"
+                    >
+                      削除
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        <MonitoringCompareField
+          label="サービス利用状況の総括"
+          fieldType="textarea"
+          currentValue={serviceUsageSummary}
+          previousValue={diffMode ? previousRecord?.serviceUsageSummary : undefined}
+          onChange={setServiceUsageSummary}
+          placeholder="サービス利用状況の総括..."
+          rows={2}
+          showDiff={diffMode}
+        />
+      </section>
+
+      {/* 利用者・家族の意向 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">利用者・家族の意向</h3>
+        <div className="space-y-4">
+          <MonitoringCompareField
+            label="利用者の意見"
+            fieldType="textarea"
+            currentValue={userOpinion}
+            previousValue={diffMode ? previousRecord?.userOpinion : undefined}
+            onChange={setUserOpinion}
+            placeholder="利用者本人の意見・希望..."
+            rows={2}
+            showDiff={diffMode}
+          />
+          <MonitoringCompareField
+            label="家族の意見"
+            fieldType="textarea"
+            currentValue={familyOpinion}
+            previousValue={diffMode ? previousRecord?.familyOpinion : undefined}
+            onChange={setFamilyOpinion}
+            placeholder="家族の意見・希望..."
+            rows={2}
+            showDiff={diffMode}
+          />
+        </div>
+      </section>
+
+      {/* 今後の対応 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">今後の対応</h3>
+        <div className="space-y-4">
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={needsPlanRevision}
+                onChange={(e) => setNeedsPlanRevision(e.target.checked)}
+                className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+              />
+              <span className="text-sm font-medium text-gray-700">
+                ケアプランの見直しが必要
+              </span>
+            </label>
+          </div>
+          {needsPlanRevision && (
+            <MonitoringCompareField
+              label="見直しが必要な理由"
+              fieldType="textarea"
+              currentValue={revisionReason}
+              previousValue={diffMode ? previousRecord?.revisionReason : undefined}
+              onChange={setRevisionReason}
+              placeholder="見直しが必要な理由..."
+              rows={2}
+              showDiff={diffMode}
+            />
+          )}
+          <MonitoringCompareField
+            label="今後の対応・申し送り"
+            fieldType="textarea"
+            currentValue={nextActions}
+            previousValue={diffMode ? previousRecord?.nextActions : undefined}
+            onChange={setNextActions}
+            placeholder="今後の対応事項..."
+            rows={3}
+            showDiff={diffMode}
+          />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              次回モニタリング予定日
+            </label>
+            <input
+              type="date"
+              value={nextMonitoringDate}
+              onChange={(e) => setNextMonitoringDate(e.target.value)}
+              className="w-full md:w-auto px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* アクションボタン */}
+      <div className="flex justify-end gap-3 pt-4">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            キャンセル
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saving ? '保存中...' : '保存'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MonitoringDiffView;

--- a/components/monitoring/index.ts
+++ b/components/monitoring/index.ts
@@ -1,3 +1,5 @@
 export { MonitoringForm } from './MonitoringForm';
 export { GoalEvaluation } from './GoalEvaluation';
-export { MonitoringView } from './MonitoringView';
+export { MonitoringDiffView } from './MonitoringDiffView';
+export { MonitoringCompareField } from './MonitoringCompareField';
+export { GoalEvaluationDiff } from './GoalEvaluationDiff';

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -293,6 +293,27 @@ export async function listMonitoringRecords(
   })) as MonitoringRecordDocument[];
 }
 
+// ケアプランIDで絞り込んだモニタリング記録一覧を取得
+export async function listMonitoringRecordsByCarePlan(
+  userId: string,
+  carePlanId: string,
+  maxResults: number = 10
+): Promise<MonitoringRecordDocument[]> {
+  const recordsRef = collection(db, 'users', userId, 'monitoringRecords');
+  const q = query(
+    recordsRef,
+    where('carePlanId', '==', carePlanId),
+    orderBy('visitDate', 'desc'),
+    limit(maxResults)
+  );
+  const snapshot = await getDocs(q);
+
+  return snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  })) as MonitoringRecordDocument[];
+}
+
 export async function deleteMonitoringRecord(userId: string, recordId: string): Promise<void> {
   const recordRef = doc(db, 'users', userId, 'monitoringRecords', recordId);
   await deleteDoc(recordRef);


### PR DESCRIPTION
## Summary

- 月次モニタリング記録作成時に前回記録との比較・差分表示機能を実装
- 前回値のコピー機能により入力効率を向上
- 目標評価の改善/悪化を視覚的に表示

## 変更内容

### 新規ファイル
- `components/monitoring/MonitoringCompareField.tsx` - 汎用差分表示フィールド
- `components/monitoring/GoalEvaluationDiff.tsx` - 目標評価の差分表示
- `components/monitoring/MonitoringDiffView.tsx` - メイン差分ビュー

### 修正ファイル
- `services/firebase.ts` - `listMonitoringRecordsByCarePlan`関数追加
- `components/monitoring/index.ts` - エクスポート追加
- `App.tsx` - `MonitoringDiffView`に置き換え

## 機能

- 前回記録の自動取得（carePlanIdで直近1件）
- 差分モードON/OFF切り替え
- 変更箇所のハイライト表示（黄色背景）
- 前回値コピーボタン（個別・一括）
- 目標評価の改善↑/悪化↓/継続→表示

## Test plan

- [ ] モニタリングタブを開き、差分モードボタンが表示されることを確認
- [ ] 前回記録がある場合、差分表示が有効になることを確認
- [ ] 「前回値をコピー」ボタンで値が引き継がれることを確認
- [ ] 変更箇所がハイライトされることを確認
- [ ] 保存後、次回の差分表示に正しく反映されることを確認
- [ ] 前回記録がない場合、通常フォームとして動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)