### PR TITLE
feat: サービス担当者会議記録（第4表）UI実装

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import { saveAssessment, listAssessments, getAssessment, deleteAssessment, Asses
 import { MonitoringDiffView } from './components/monitoring';
 import { SupportRecordForm, SupportRecordList } from './components/records';
 import { HospitalAdmissionSheetView } from './components/documents';
+import { ServiceMeetingForm, ServiceMeetingList } from './components/meeting';
 import { generateHospitalAdmissionSheet, UserBasicInfo, CareManagerInfo } from './utils/hospitalAdmissionSheet';
 
 // --- Mock Data ---
@@ -75,7 +76,7 @@ const INITIAL_ASSESSMENT: AssessmentData = {
 
 export default function App() {
   const { user, loading, logout } = useAuth();
-  const [activeTab, setActiveTab] = useState<'assessment' | 'plan' | 'monitoring' | 'records'>('assessment');
+  const [activeTab, setActiveTab] = useState<'assessment' | 'plan' | 'monitoring' | 'records' | 'meeting'>('assessment');
 
   // Data State
   const [plan, setPlan] = useState<CarePlan>(INITIAL_PLAN);
@@ -478,7 +479,8 @@ export default function App() {
             { id: 'assessment', icon: FileText, label: 'アセスメント' },
             { id: 'plan', icon: ShieldCheck, label: 'ケアプラン' },
             { id: 'monitoring', icon: Activity, label: 'モニタリング' },
-            { id: 'records', icon: Users, label: '支援経過' },
+            { id: 'records', icon: FileText, label: '支援経過' },
+            { id: 'meeting', icon: Users, label: '担当者会議' },
           ].map((tab) => (
             <button
               key={tab.id}
@@ -900,6 +902,35 @@ export default function App() {
                   <h3 className="text-lg font-bold text-stone-800 mb-4">記録一覧</h3>
                   <SupportRecordList
                     userId={user?.uid || MOCK_USER.id}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* VIEW: Service Meeting */}
+          {activeTab === 'meeting' && (
+            <div className="animate-in fade-in duration-300">
+              <div className="mb-4">
+                <h2 className="text-xl font-bold text-stone-800 mb-1">サービス担当者会議記録（第4表）</h2>
+                <p className="text-sm text-stone-500">
+                  担当者会議の記録・照会内容を管理
+                </p>
+              </div>
+              <div className="space-y-6">
+                <ServiceMeetingForm
+                  userId={user?.uid || MOCK_USER.id}
+                  carePlanId={plan.id}
+                  onSave={(recordId) => {
+                    setSaveMessage({ type: 'success', text: '担当者会議記録を保存しました' });
+                    setTimeout(() => setSaveMessage(null), 3000);
+                  }}
+                />
+                <div className="border-t border-stone-200 pt-6">
+                  <h3 className="text-lg font-bold text-stone-800 mb-4">会議記録一覧</h3>
+                  <ServiceMeetingList
+                    userId={user?.uid || MOCK_USER.id}
+                    carePlanId={plan.id}
                   />
                 </div>
               </div>

--- a/components/meeting/AgendaItemEditor.tsx
+++ b/components/meeting/AgendaItemEditor.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Trash2, GripVertical } from 'lucide-react';
+import type { MeetingAgendaItem } from '../../types';
+
+interface AgendaItemEditorProps {
+  item: MeetingAgendaItem;
+  index: number;
+  onChange: (updated: MeetingAgendaItem) => void;
+  onRemove: () => void;
+}
+
+export const AgendaItemEditor: React.FC<AgendaItemEditorProps> = ({
+  item,
+  index,
+  onChange,
+  onRemove,
+}) => {
+  const handleChange = (field: keyof MeetingAgendaItem, value: string) => {
+    onChange({ ...item, [field]: value });
+  };
+
+  return (
+    <div className="border rounded-lg p-4 bg-white shadow-sm">
+      <div className="flex items-start gap-3">
+        <div className="flex items-center gap-2 text-gray-400 pt-1">
+          <GripVertical className="w-4 h-4" />
+          <span className="text-sm font-bold">{index + 1}</span>
+        </div>
+
+        <div className="flex-1 space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">
+              検討項目
+            </label>
+            <input
+              type="text"
+              value={item.topic}
+              onChange={(e) => handleChange('topic', e.target.value)}
+              placeholder="例: 入浴サービスの頻度について"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">
+              検討内容
+            </label>
+            <textarea
+              value={item.discussion}
+              onChange={(e) => handleChange('discussion', e.target.value)}
+              placeholder="各担当者からの意見・検討された内容"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              rows={2}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">
+                結論
+              </label>
+              <textarea
+                value={item.conclusion}
+                onChange={(e) => handleChange('conclusion', e.target.value)}
+                placeholder="検討の結果・決定事項"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                rows={2}
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">
+                担当者/事業所
+              </label>
+              <input
+                type="text"
+                value={item.responsible || ''}
+                onChange={(e) => handleChange('responsible', e.target.value)}
+                placeholder="担当する事業所・担当者名"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onRemove}
+          className="p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AgendaItemEditor;

--- a/components/meeting/AttendeeEditor.tsx
+++ b/components/meeting/AttendeeEditor.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Trash2 } from 'lucide-react';
+import type { MeetingAttendee } from '../../types';
+
+interface AttendeeEditorProps {
+  attendee: MeetingAttendee;
+  onChange: (updated: MeetingAttendee) => void;
+  onRemove: () => void;
+}
+
+export const AttendeeEditor: React.FC<AttendeeEditorProps> = ({
+  attendee,
+  onChange,
+  onRemove,
+}) => {
+  const handleChange = (field: keyof MeetingAttendee, value: string | boolean) => {
+    onChange({ ...attendee, [field]: value });
+  };
+
+  return (
+    <div className="border rounded-lg p-3 bg-gray-50">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-2">
+        <input
+          type="text"
+          value={attendee.name}
+          onChange={(e) => handleChange('name', e.target.value)}
+          placeholder="氏名"
+          className="px-2 py-1 border border-gray-300 rounded text-sm"
+        />
+        <input
+          type="text"
+          value={attendee.organization}
+          onChange={(e) => handleChange('organization', e.target.value)}
+          placeholder="所属事業所"
+          className="px-2 py-1 border border-gray-300 rounded text-sm"
+        />
+        <input
+          type="text"
+          value={attendee.profession}
+          onChange={(e) => handleChange('profession', e.target.value)}
+          placeholder="職種"
+          className="px-2 py-1 border border-gray-300 rounded text-sm"
+        />
+        <div className="flex items-center gap-2">
+          <label className="flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={attendee.attended}
+              onChange={(e) => handleChange('attended', e.target.checked)}
+              className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+            />
+            <span className="text-sm text-gray-700">出席</span>
+          </label>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="ml-auto p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* 欠席時の照会情報 */}
+      {!attendee.attended && (
+        <div className="mt-2 pt-2 border-t border-gray-200 bg-amber-50 -mx-3 -mb-3 p-3 rounded-b-lg">
+          <p className="text-xs font-medium text-amber-700 mb-2">照会情報（欠席のため）</p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+            <input
+              type="text"
+              value={attendee.inquiryMethod || ''}
+              onChange={(e) => handleChange('inquiryMethod', e.target.value)}
+              placeholder="照会方法（電話/FAX/メール等）"
+              className="px-2 py-1 border border-amber-300 rounded text-sm bg-white"
+            />
+            <input
+              type="date"
+              value={attendee.inquiryDate || ''}
+              onChange={(e) => handleChange('inquiryDate', e.target.value)}
+              className="px-2 py-1 border border-amber-300 rounded text-sm bg-white"
+            />
+            <input
+              type="text"
+              value={attendee.inquiryResponse || ''}
+              onChange={(e) => handleChange('inquiryResponse', e.target.value)}
+              placeholder="照会回答内容"
+              className="px-2 py-1 border border-amber-300 rounded text-sm bg-white"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AttendeeEditor;

--- a/components/meeting/ServiceMeetingForm.tsx
+++ b/components/meeting/ServiceMeetingForm.tsx
@@ -1,0 +1,471 @@
+import React, { useState, useEffect } from 'react';
+import { Timestamp } from 'firebase/firestore';
+import { Plus } from 'lucide-react';
+import { AttendeeEditor } from './AttendeeEditor';
+import { AgendaItemEditor } from './AgendaItemEditor';
+import {
+  saveServiceMeetingRecord,
+  getServiceMeetingRecord,
+  type ServiceMeetingRecordDocument,
+} from '../../services/firebase';
+import type { MeetingAttendee, MeetingAgendaItem, MeetingFormat } from '../../types';
+
+interface ServiceMeetingFormProps {
+  userId: string;
+  carePlanId: string;
+  existingRecordId?: string;
+  onSave?: (recordId: string) => void;
+  onCancel?: () => void;
+}
+
+const meetingFormatOptions: { value: MeetingFormat; label: string }[] = [
+  { value: 'in_person', label: '対面開催' },
+  { value: 'online', label: 'オンライン開催' },
+  { value: 'hybrid', label: 'ハイブリッド' },
+];
+
+const meetingPurposeOptions = [
+  '新規ケアプラン作成',
+  'ケアプラン更新',
+  'ケアプラン変更',
+  '緊急対応',
+  'その他',
+];
+
+export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
+  userId,
+  carePlanId,
+  existingRecordId,
+  onSave,
+  onCancel,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // 基本情報
+  const [meetingDate, setMeetingDate] = useState(
+    new Date().toISOString().slice(0, 16)
+  );
+  const [meetingLocation, setMeetingLocation] = useState('');
+  const [meetingFormat, setMeetingFormat] = useState<MeetingFormat>('in_person');
+  const [meetingPurpose, setMeetingPurpose] = useState('新規ケアプラン作成');
+
+  // 出席者
+  const [attendees, setAttendees] = useState<MeetingAttendee[]>([]);
+
+  // 利用者・家族
+  const [userAttended, setUserAttended] = useState(true);
+  const [userOpinion, setUserOpinion] = useState('');
+  const [familyAttended, setFamilyAttended] = useState(true);
+  const [familyOpinion, setFamilyOpinion] = useState('');
+
+  // 検討事項
+  const [agendaItems, setAgendaItems] = useState<MeetingAgendaItem[]>([]);
+
+  // ケアプラン同意
+  const [carePlanExplained, setCarePlanExplained] = useState(false);
+  const [carePlanAgreed, setCarePlanAgreed] = useState(false);
+  const [carePlanModifications, setCarePlanModifications] = useState('');
+
+  // その他
+  const [remainingIssues, setRemainingIssues] = useState('');
+  const [nextMeetingSchedule, setNextMeetingSchedule] = useState('');
+
+  // 既存レコードの読み込み
+  useEffect(() => {
+    if (existingRecordId) {
+      loadExistingRecord();
+    }
+  }, [existingRecordId]);
+
+  const loadExistingRecord = async () => {
+    if (!existingRecordId) return;
+
+    setLoading(true);
+    try {
+      const record = await getServiceMeetingRecord(userId, existingRecordId);
+      if (record) {
+        setMeetingDate(record.meetingDate.toDate().toISOString().slice(0, 16));
+        setMeetingLocation(record.meetingLocation);
+        setMeetingFormat(record.meetingFormat);
+        setMeetingPurpose(record.meetingPurpose);
+        setAttendees(record.attendees);
+        setUserAttended(record.userAttended);
+        setUserOpinion(record.userOpinion);
+        setFamilyAttended(record.familyAttended);
+        setFamilyOpinion(record.familyOpinion);
+        setAgendaItems(record.agendaItems);
+        setCarePlanExplained(record.carePlanExplained);
+        setCarePlanAgreed(record.carePlanAgreed);
+        setCarePlanModifications(record.carePlanModifications);
+        setRemainingIssues(record.remainingIssues);
+        setNextMeetingSchedule(record.nextMeetingSchedule);
+      }
+    } catch (error) {
+      console.error('Failed to load existing record:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 出席者管理
+  const addAttendee = () => {
+    setAttendees((prev) => [
+      ...prev,
+      {
+        name: '',
+        organization: '',
+        profession: '',
+        attended: true,
+      },
+    ]);
+  };
+
+  const updateAttendee = (index: number, updated: MeetingAttendee) => {
+    setAttendees((prev) =>
+      prev.map((a, i) => (i === index ? updated : a))
+    );
+  };
+
+  const removeAttendee = (index: number) => {
+    setAttendees((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  // 検討事項管理
+  const addAgendaItem = () => {
+    setAgendaItems((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        topic: '',
+        discussion: '',
+        conclusion: '',
+        responsible: '',
+      },
+    ]);
+  };
+
+  const updateAgendaItem = (index: number, updated: MeetingAgendaItem) => {
+    setAgendaItems((prev) =>
+      prev.map((item, i) => (i === index ? updated : item))
+    );
+  };
+
+  const removeAgendaItem = (index: number) => {
+    setAgendaItems((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  // 保存
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const recordId = existingRecordId || `meeting_${Date.now()}`;
+
+      const data: Omit<ServiceMeetingRecordDocument, 'id' | 'createdAt' | 'updatedAt'> = {
+        userId,
+        carePlanId,
+        meetingDate: Timestamp.fromDate(new Date(meetingDate)),
+        meetingLocation,
+        meetingFormat,
+        meetingPurpose,
+        attendees,
+        userAttended,
+        userOpinion,
+        familyAttended,
+        familyOpinion,
+        agendaItems,
+        carePlanExplained,
+        carePlanAgreed,
+        carePlanModifications,
+        remainingIssues,
+        nextMeetingSchedule,
+        createdBy: userId,
+      };
+
+      await saveServiceMeetingRecord(userId, recordId, data);
+
+      if (onSave) {
+        onSave(recordId);
+      }
+    } catch (error) {
+      console.error('Failed to save service meeting record:', error);
+      alert('保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        <span className="ml-2 text-gray-600">読み込み中...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4 max-w-4xl mx-auto">
+      <h2 className="text-xl font-bold text-gray-900">サービス担当者会議記録（第4表）</h2>
+
+      {/* 会議基本情報 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">会議基本情報</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              開催日時
+            </label>
+            <input
+              type="datetime-local"
+              value={meetingDate}
+              onChange={(e) => setMeetingDate(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              開催場所
+            </label>
+            <input
+              type="text"
+              value={meetingLocation}
+              onChange={(e) => setMeetingLocation(e.target.value)}
+              placeholder="例: 利用者宅、○○デイサービス、オンライン"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              開催方式
+            </label>
+            <select
+              value={meetingFormat}
+              onChange={(e) => setMeetingFormat(e.target.value as MeetingFormat)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {meetingFormatOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              開催目的
+            </label>
+            <select
+              value={meetingPurpose}
+              onChange={(e) => setMeetingPurpose(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {meetingPurposeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {/* 出席者 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold text-gray-800">出席者</h3>
+          <button
+            type="button"
+            onClick={addAttendee}
+            className="flex items-center gap-1 px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            <Plus className="w-4 h-4" />
+            出席者を追加
+          </button>
+        </div>
+        {attendees.length === 0 ? (
+          <p className="text-gray-500 text-sm">出席者を追加してください</p>
+        ) : (
+          <div className="space-y-3">
+            {attendees.map((attendee, index) => (
+              <AttendeeEditor
+                key={index}
+                attendee={attendee}
+                onChange={(updated) => updateAttendee(index, updated)}
+                onRemove={() => removeAttendee(index)}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* 利用者・家族の参加 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">利用者・家族の参加</h3>
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="flex items-center gap-2 mb-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={userAttended}
+                  onChange={(e) => setUserAttended(e.target.checked)}
+                  className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm font-medium text-gray-700">利用者本人が出席</span>
+              </label>
+              <textarea
+                value={userOpinion}
+                onChange={(e) => setUserOpinion(e.target.value)}
+                placeholder="利用者の発言・意向"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                rows={2}
+              />
+            </div>
+            <div>
+              <label className="flex items-center gap-2 mb-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={familyAttended}
+                  onChange={(e) => setFamilyAttended(e.target.checked)}
+                  className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm font-medium text-gray-700">家族が出席</span>
+              </label>
+              <textarea
+                value={familyOpinion}
+                onChange={(e) => setFamilyOpinion(e.target.value)}
+                placeholder="家族の発言・意向"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                rows={2}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 検討事項 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold text-gray-800">検討事項</h3>
+          <button
+            type="button"
+            onClick={addAgendaItem}
+            className="flex items-center gap-1 px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            <Plus className="w-4 h-4" />
+            検討事項を追加
+          </button>
+        </div>
+        {agendaItems.length === 0 ? (
+          <p className="text-gray-500 text-sm">検討事項を追加してください</p>
+        ) : (
+          <div className="space-y-4">
+            {agendaItems.map((item, index) => (
+              <AgendaItemEditor
+                key={item.id}
+                item={item}
+                index={index}
+                onChange={(updated) => updateAgendaItem(index, updated)}
+                onRemove={() => removeAgendaItem(index)}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ケアプラン同意状況 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">ケアプラン原案の説明・同意</h3>
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={carePlanExplained}
+                onChange={(e) => setCarePlanExplained(e.target.checked)}
+                className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+              />
+              <span className="text-sm font-medium text-gray-700">ケアプラン原案を説明した</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={carePlanAgreed}
+                onChange={(e) => setCarePlanAgreed(e.target.checked)}
+                className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+              />
+              <span className="text-sm font-medium text-gray-700">同意を得た</span>
+            </label>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              会議を踏まえた修正点
+            </label>
+            <textarea
+              value={carePlanModifications}
+              onChange={(e) => setCarePlanModifications(e.target.value)}
+              placeholder="会議での検討を踏まえて修正した点"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              rows={2}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* 残された課題・次回予定 */}
+      <section className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">残された課題・次回予定</h3>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              残された課題
+            </label>
+            <textarea
+              value={remainingIssues}
+              onChange={(e) => setRemainingIssues(e.target.value)}
+              placeholder="今後検討が必要な課題"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              rows={2}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              次回会議予定
+            </label>
+            <input
+              type="text"
+              value={nextMeetingSchedule}
+              onChange={(e) => setNextMeetingSchedule(e.target.value)}
+              placeholder="例: 3ヶ月後（状態変化時は随時）"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* アクションボタン */}
+      <div className="flex justify-end gap-3 pt-4">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            キャンセル
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saving ? '保存中...' : '保存'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceMeetingForm;

--- a/components/meeting/ServiceMeetingList.tsx
+++ b/components/meeting/ServiceMeetingList.tsx
@@ -1,0 +1,187 @@
+import React, { useState, useEffect } from 'react';
+import { Calendar, MapPin, Users, Trash2, ChevronRight } from 'lucide-react';
+import {
+  listServiceMeetingRecords,
+  listServiceMeetingRecordsByCarePlan,
+  deleteServiceMeetingRecord,
+  type ServiceMeetingRecordDocument,
+} from '../../services/firebase';
+
+interface ServiceMeetingListProps {
+  userId: string;
+  carePlanId?: string;
+  onSelect?: (recordId: string) => void;
+  onDelete?: (recordId: string) => void;
+}
+
+const formatLabel: Record<string, string> = {
+  in_person: '対面',
+  online: 'オンライン',
+  hybrid: 'ハイブリッド',
+};
+
+export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
+  userId,
+  carePlanId,
+  onSelect,
+  onDelete,
+}) => {
+  const [records, setRecords] = useState<ServiceMeetingRecordDocument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadRecords();
+  }, [userId, carePlanId]);
+
+  const loadRecords = async () => {
+    setLoading(true);
+    try {
+      const list = carePlanId
+        ? await listServiceMeetingRecordsByCarePlan(userId, carePlanId)
+        : await listServiceMeetingRecords(userId);
+      setRecords(list);
+    } catch (error) {
+      console.error('Failed to load meeting records:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (recordId: string) => {
+    setDeletingId(recordId);
+    try {
+      await deleteServiceMeetingRecord(userId, recordId);
+      setRecords((prev) => prev.filter((r) => r.id !== recordId));
+      if (onDelete) {
+        onDelete(recordId);
+      }
+    } catch (error) {
+      console.error('Failed to delete meeting record:', error);
+      alert('削除に失敗しました');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+        <span className="ml-2 text-gray-600 text-sm">読み込み中...</span>
+      </div>
+    );
+  }
+
+  if (records.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500">
+        <Users className="w-12 h-12 mx-auto mb-3 text-gray-300" />
+        <p className="text-sm">会議記録がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {records.map((record) => {
+        const meetingDate = record.meetingDate.toDate();
+        const attendeeCount = record.attendees.length;
+        const presentCount = record.attendees.filter((a) => a.attended).length;
+
+        return (
+          <div
+            key={record.id}
+            className="bg-white border border-gray-200 rounded-lg p-4 hover:border-blue-300 hover:shadow-sm transition-all"
+          >
+            <div className="flex items-start justify-between">
+              <div
+                className="flex-1 cursor-pointer"
+                onClick={() => onSelect && onSelect(record.id)}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                    {record.meetingPurpose}
+                  </span>
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">
+                    {formatLabel[record.meetingFormat] || record.meetingFormat}
+                  </span>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm text-gray-600">
+                  <div className="flex items-center gap-1.5">
+                    <Calendar className="w-4 h-4 text-gray-400" />
+                    <span>
+                      {meetingDate.toLocaleDateString('ja-JP', {
+                        year: 'numeric',
+                        month: '2-digit',
+                        day: '2-digit',
+                      })}
+                      {' '}
+                      {meetingDate.toLocaleTimeString('ja-JP', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-1.5">
+                    <MapPin className="w-4 h-4 text-gray-400" />
+                    <span className="truncate">{record.meetingLocation || '未設定'}</span>
+                  </div>
+
+                  <div className="flex items-center gap-1.5">
+                    <Users className="w-4 h-4 text-gray-400" />
+                    <span>
+                      出席 {presentCount}/{attendeeCount}名
+                      {record.userAttended && ' + 利用者'}
+                      {record.familyAttended && ' + 家族'}
+                    </span>
+                  </div>
+                </div>
+
+                {record.agendaItems.length > 0 && (
+                  <div className="mt-2 pt-2 border-t border-gray-100">
+                    <p className="text-xs text-gray-500 mb-1">検討事項:</p>
+                    <ul className="text-sm text-gray-700">
+                      {record.agendaItems.slice(0, 2).map((item) => (
+                        <li key={item.id} className="truncate">
+                          - {item.topic}
+                        </li>
+                      ))}
+                      {record.agendaItems.length > 2 && (
+                        <li className="text-gray-400 text-xs">
+                          他 {record.agendaItems.length - 2} 件
+                        </li>
+                      )}
+                    </ul>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2 ml-4">
+                <button
+                  onClick={() => handleDelete(record.id)}
+                  disabled={deletingId === record.id}
+                  className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded disabled:opacity-50"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+                {onSelect && (
+                  <button
+                    onClick={() => onSelect(record.id)}
+                    className="p-2 text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded"
+                  >
+                    <ChevronRight className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ServiceMeetingList;

--- a/components/meeting/index.ts
+++ b/components/meeting/index.ts
@@ -1,0 +1,4 @@
+export { ServiceMeetingForm } from './ServiceMeetingForm';
+export { ServiceMeetingList } from './ServiceMeetingList';
+export { AttendeeEditor } from './AttendeeEditor';
+export { AgendaItemEditor } from './AgendaItemEditor';


### PR DESCRIPTION
## Summary
- サービス担当者会議記録（第4表）のCRUD UIを実装
- 既存のMonitoringForm/SupportRecordFormパターンに準拠
- App.tsxに「担当者会議」タブを追加

## 変更内容
| ファイル | 内容 |
|---------|------|
| `components/meeting/AttendeeEditor.tsx` | 出席者の動的編集（氏名/所属/職種、出席/欠席、照会情報） |
| `components/meeting/AgendaItemEditor.tsx` | 検討事項の動的編集（検討項目/検討内容/結論/担当者） |
| `components/meeting/ServiceMeetingForm.tsx` | メインフォーム（会議基本情報、出席者管理、利用者・家族参加、検討事項、ケアプラン同意、残課題） |
| `components/meeting/ServiceMeetingList.tsx` | 会議記録一覧（日時/場所/出席者数/検討事項表示、削除機能） |
| `components/meeting/index.ts` | エクスポート |
| `App.tsx` | 「担当者会議」タブ追加・コンポーネント統合 |

## Test plan
- [ ] 新規会議記録の作成・保存
- [ ] 出席者の追加/削除
- [ ] 欠席者の照会情報入力
- [ ] 検討事項の追加/削除
- [ ] 既存記録の一覧表示
- [ ] 記録の削除
- [ ] タブ切り替え動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)