### PR TITLE
feat: モニタリング履歴一覧・編集機能を追加

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import { LoginScreen } from './components/auth';
 import { useAuth } from './contexts/AuthContext';
 import { PrintPreview } from './components/careplan';
 import { saveAssessment, listAssessments, getAssessment, deleteAssessment, AssessmentDocument, saveCarePlan } from './services/firebase';
-import { MonitoringDiffView } from './components/monitoring';
+import { MonitoringDiffView, MonitoringRecordList } from './components/monitoring';
 import { SupportRecordForm, SupportRecordList } from './components/records';
 import { HospitalAdmissionSheetView } from './components/documents';
 import { ServiceMeetingForm, ServiceMeetingList } from './components/meeting';
@@ -106,6 +106,10 @@ export default function App() {
   // Hospital Admission Sheet State
   const [showHospitalSheet, setShowHospitalSheet] = useState(false);
   const [hospitalSheet, setHospitalSheet] = useState<HospitalAdmissionSheet | null>(null);
+
+  // Monitoring State
+  const [monitoringMode, setMonitoringMode] = useState<'list' | 'edit'>('list');
+  const [editingMonitoringId, setEditingMonitoringId] = useState<string | null>(null);
 
   // Validation Effect
   useEffect(() => {
@@ -862,21 +866,55 @@ export default function App() {
           {/* VIEW: Monitoring */}
           {activeTab === 'monitoring' && (
             <div className="animate-in fade-in duration-300">
-              <div className="mb-4">
-                <h2 className="text-xl font-bold text-stone-800 mb-1">モニタリング記録</h2>
-                <p className="text-sm text-stone-500">
-                  月次モニタリング・目標達成状況の評価
-                </p>
-              </div>
-              <MonitoringDiffView
-                userId={user?.uid || MOCK_USER.id}
-                carePlanId={plan.id}
-                goals={plan.shortTermGoals}
-                onSave={(recordId) => {
-                  setSaveMessage({ type: 'success', text: 'モニタリング記録を保存しました' });
-                  setTimeout(() => setSaveMessage(null), 3000);
-                }}
-              />
+              {monitoringMode === 'list' ? (
+                <>
+                  <div className="mb-4 flex items-center justify-between">
+                    <div>
+                      <h2 className="text-xl font-bold text-stone-800 mb-1">モニタリング記録</h2>
+                      <p className="text-sm text-stone-500">
+                        月次モニタリング・目標達成状況の評価
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => {
+                        setEditingMonitoringId(null);
+                        setMonitoringMode('edit');
+                      }}
+                      className="flex items-center gap-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+                    >
+                      <Plus className="w-4 h-4" />
+                      新規作成
+                    </button>
+                  </div>
+                  <MonitoringRecordList
+                    userId={user?.uid || MOCK_USER.id}
+                    carePlanId={plan.id}
+                    onSelect={(recordId) => {
+                      setEditingMonitoringId(recordId);
+                      setMonitoringMode('edit');
+                    }}
+                    onDelete={() => {
+                      setSaveMessage({ type: 'success', text: 'モニタリング記録を削除しました' });
+                    }}
+                  />
+                </>
+              ) : (
+                <MonitoringDiffView
+                  userId={user?.uid || MOCK_USER.id}
+                  carePlanId={plan.id}
+                  goals={plan.shortTermGoals}
+                  existingRecordId={editingMonitoringId || undefined}
+                  onSave={() => {
+                    setSaveMessage({ type: 'success', text: 'モニタリング記録を保存しました' });
+                    setMonitoringMode('list');
+                    setEditingMonitoringId(null);
+                  }}
+                  onCancel={() => {
+                    setMonitoringMode('list');
+                    setEditingMonitoringId(null);
+                  }}
+                />
+              )}
             </div>
           )}
 

--- a/components/monitoring/MonitoringRecordList.tsx
+++ b/components/monitoring/MonitoringRecordList.tsx
@@ -1,0 +1,199 @@
+import React, { useState, useEffect } from 'react';
+import { Calendar, Activity, Trash2, ChevronRight, CheckCircle, AlertCircle, MinusCircle } from 'lucide-react';
+import {
+  listMonitoringRecords,
+  listMonitoringRecordsByCarePlan,
+  deleteMonitoringRecord,
+  type MonitoringRecordDocument,
+} from '../../services/firebase';
+
+interface MonitoringRecordListProps {
+  userId: string;
+  carePlanId?: string;
+  onSelect?: (recordId: string) => void;
+  onDelete?: (recordId: string) => void;
+}
+
+const visitMethodLabels: Record<string, string> = {
+  home_visit: '居宅訪問',
+  online: 'オンライン',
+  phone: '電話',
+};
+
+export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
+  userId,
+  carePlanId,
+  onSelect,
+  onDelete,
+}) => {
+  const [records, setRecords] = useState<MonitoringRecordDocument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadRecords();
+  }, [userId, carePlanId]);
+
+  const loadRecords = async () => {
+    setLoading(true);
+    try {
+      const list = carePlanId
+        ? await listMonitoringRecordsByCarePlan(userId, carePlanId)
+        : await listMonitoringRecords(userId);
+      setRecords(list);
+    } catch (error) {
+      console.error('Failed to load monitoring records:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (recordId: string) => {
+    if (!confirm('この記録を削除してもよろしいですか？')) {
+      return;
+    }
+    setDeletingId(recordId);
+    try {
+      await deleteMonitoringRecord(userId, recordId);
+      setRecords((prev) => prev.filter((r) => r.id !== recordId));
+      if (onDelete) {
+        onDelete(recordId);
+      }
+    } catch (error) {
+      console.error('Failed to delete monitoring record:', error);
+      alert('削除に失敗しました');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  // 目標評価のサマリーを計算
+  const getEvaluationSummary = (record: MonitoringRecordDocument) => {
+    const counts: Record<string, number> = {};
+    record.goalEvaluations.forEach((e) => {
+      counts[e.status] = (counts[e.status] || 0) + 1;
+    });
+    return counts;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+        <span className="ml-2 text-gray-600 text-sm">読み込み中...</span>
+      </div>
+    );
+  }
+
+  if (records.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500">
+        <Activity className="w-12 h-12 mx-auto mb-3 text-gray-300" />
+        <p className="text-sm">モニタリング記録がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {records.map((record) => {
+        const visitDate = record.visitDate.toDate();
+        const summary = getEvaluationSummary(record);
+
+        return (
+          <div
+            key={record.id}
+            className="bg-white border border-gray-200 rounded-lg p-4 hover:border-blue-300 hover:shadow-sm transition-all"
+          >
+            <div className="flex items-start justify-between">
+              <div
+                className="flex-1 cursor-pointer"
+                onClick={() => onSelect && onSelect(record.id)}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                    {visitMethodLabels[record.visitMethod] || record.visitMethod}
+                  </span>
+                  {record.needsPlanRevision && (
+                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
+                      見直し要
+                    </span>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-gray-600">
+                  <div className="flex items-center gap-1.5">
+                    <Calendar className="w-4 h-4 text-gray-400" />
+                    <span>
+                      {visitDate.toLocaleDateString('ja-JP', {
+                        year: 'numeric',
+                        month: '2-digit',
+                        day: '2-digit',
+                      })}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    {summary.achieved > 0 && (
+                      <span className="inline-flex items-center gap-0.5 text-green-600">
+                        <CheckCircle className="w-3.5 h-3.5" />
+                        <span className="text-xs">{summary.achieved}</span>
+                      </span>
+                    )}
+                    {summary.progressing > 0 && (
+                      <span className="inline-flex items-center gap-0.5 text-blue-600">
+                        <Activity className="w-3.5 h-3.5" />
+                        <span className="text-xs">{summary.progressing}</span>
+                      </span>
+                    )}
+                    {summary.declined > 0 && (
+                      <span className="inline-flex items-center gap-0.5 text-red-600">
+                        <AlertCircle className="w-3.5 h-3.5" />
+                        <span className="text-xs">{summary.declined}</span>
+                      </span>
+                    )}
+                    {summary.unchanged > 0 && (
+                      <span className="inline-flex items-center gap-0.5 text-gray-500">
+                        <MinusCircle className="w-3.5 h-3.5" />
+                        <span className="text-xs">{summary.unchanged}</span>
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {record.overallCondition && (
+                  <div className="mt-2 pt-2 border-t border-gray-100">
+                    <p className="text-xs text-gray-500 mb-1">全体的な状態:</p>
+                    <p className="text-sm text-gray-700 line-clamp-2">
+                      {record.overallCondition}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2 ml-4">
+                <button
+                  onClick={() => handleDelete(record.id)}
+                  disabled={deletingId === record.id}
+                  className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded disabled:opacity-50"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+                {onSelect && (
+                  <button
+                    onClick={() => onSelect(record.id)}
+                    className="p-2 text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded"
+                  >
+                    <ChevronRight className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MonitoringRecordList;

--- a/components/monitoring/index.ts
+++ b/components/monitoring/index.ts
@@ -3,3 +3,4 @@ export { GoalEvaluation } from './GoalEvaluation';
 export { MonitoringDiffView } from './MonitoringDiffView';
 export { MonitoringCompareField } from './MonitoringCompareField';
 export { GoalEvaluationDiff } from './GoalEvaluationDiff';
+export { MonitoringRecordList } from './MonitoringRecordList';


### PR DESCRIPTION
## Summary
- モニタリングタブに履歴一覧表示機能を追加
- 既存記録の選択・編集が可能に
- ServiceMeetingListと同じUIパターンで実装

## 変更内容
- `MonitoringRecordList` コンポーネント新規作成
  - 履歴一覧表示（実施日、実施方法、見直し要否）
  - 目標評価サマリー（達成/継続中/低下等のアイコン表示）
  - 確認ダイアログ付き削除機能
- `App.tsx` にモード切替ロジック追加
  - 一覧モード → 編集モード（新規/既存）
  - 保存/キャンセルで一覧に戻る

## Test plan
- [ ] モニタリングタブで一覧表示を確認
- [ ] 新規作成ボタンでフォーム表示、保存後に一覧へ戻ることを確認
- [ ] 既存記録を選択して編集、保存/キャンセルで一覧に戻ることを確認
- [ ] 削除機能の動作確認（確認ダイアログ表示）
- [ ] `npm run build` でビルドエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)