### PR TITLE
feat: UX改善バッチ（検索・進捗・定型文）

### DIFF
--- a/components/assessment/TouchAssessment.tsx
+++ b/components/assessment/TouchAssessment.tsx
@@ -18,39 +18,55 @@ const INITIAL_ADVICE = [
 ];
 
 // Phase 3 & 4: Hybrid Input with AI Highlight Support
-const QuickOptions = ({ 
-    label, 
-    options, 
-    selected, 
-    onSelect, 
-    placeholder = "詳細を入力...", 
-    isAiUpdated = false 
-}: { 
-    label: string, 
-    options: string[], 
-    selected: string, 
-    onSelect: (val: string) => void, 
+const QuickOptions = ({
+    label,
+    options,
+    selected,
+    onSelect,
+    placeholder = "詳細を入力...",
+    isAiUpdated = false,
+    isEmpty = false
+}: {
+    label: string,
+    options: string[],
+    selected: string,
+    onSelect: (val: string) => void,
     placeholder?: string,
-    isAiUpdated?: boolean
+    isAiUpdated?: boolean,
+    isEmpty?: boolean
 }) => {
     return (
-        <div className={`mb-6 p-4 rounded-lg border shadow-sm transition-all duration-500 ${isAiUpdated ? 'bg-indigo-50 border-indigo-300 ring-1 ring-indigo-200' : 'bg-white border-stone-100'}`}>
+        <div className={`mb-6 p-4 rounded-lg border shadow-sm transition-all duration-500 ${
+            isAiUpdated ? 'bg-indigo-50 border-indigo-300 ring-1 ring-indigo-200'
+            : isEmpty ? 'bg-amber-50/50 border-amber-200'
+            : 'bg-white border-stone-100'
+        }`}>
             <div className="flex justify-between items-center mb-3">
                 <label className="block text-sm font-bold text-stone-700 flex items-center gap-2">
-                    <span className={`w-1.5 h-4 rounded-full ${isAiUpdated ? 'bg-indigo-500' : 'bg-blue-500'}`}></span>
+                    <span className={`w-1.5 h-4 rounded-full ${
+                        isAiUpdated ? 'bg-indigo-500' : isEmpty ? 'bg-amber-400' : 'bg-blue-500'
+                    }`}></span>
                     {label}
                 </label>
-                {isAiUpdated && (
-                    <span className="flex items-center gap-1 text-[10px] font-bold text-indigo-600 bg-white px-2 py-0.5 rounded-full border border-indigo-200 animate-pulse">
-                        <Sparkles className="w-3 h-3" />
-                        AI自動入力
-                    </span>
-                )}
+                <div className="flex items-center gap-2">
+                    {isEmpty && !isAiUpdated && (
+                        <span className="flex items-center gap-1 text-[10px] font-bold text-amber-600 bg-amber-100 px-2 py-0.5 rounded-full border border-amber-200">
+                            <AlertTriangle className="w-3 h-3" />
+                            未入力
+                        </span>
+                    )}
+                    {isAiUpdated && (
+                        <span className="flex items-center gap-1 text-[10px] font-bold text-indigo-600 bg-white px-2 py-0.5 rounded-full border border-indigo-200 animate-pulse">
+                            <Sparkles className="w-3 h-3" />
+                            AI自動入力
+                        </span>
+                    )}
+                </div>
             </div>
-            
+
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-3">
                 {options.map((opt) => (
-                    <button 
+                    <button
                         key={opt}
                         onClick={() => onSelect(opt)}
                         className={`
@@ -65,7 +81,7 @@ const QuickOptions = ({
                     </button>
                 ))}
             </div>
-            <textarea 
+            <textarea
                 className="w-full p-3 text-sm border border-stone-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-stone-900"
                 rows={2}
                 placeholder={placeholder}
@@ -122,9 +138,27 @@ const InterviewCoPilot = ({ advice }: { advice: string[] }) => {
     );
 };
 
+// タブ定義
+const tabDefinitions = [
+    { id: 'health', label: '基本・健康', icon: Activity, fields: ['serviceHistory', 'healthStatus', 'pastHistory', 'skinCondition', 'oralHygiene', 'fluidIntake'] },
+    { id: 'adl', label: '生活機能', icon: Home, fields: ['adlTransfer', 'adlEating', 'adlToileting', 'adlBathing', 'adlDressing', 'iadlCooking', 'iadlShopping', 'iadlMoney', 'medication'] },
+    { id: 'mental', label: '認知・精神', icon: Brain, fields: ['cognition', 'communication'] },
+    { id: 'social', label: '社会・環境', icon: Users, fields: ['socialParticipation', 'residence', 'familySituation', 'maltreatmentRisk', 'environment'] },
+    { id: 'summary', label: '全体サマリー', icon: ClipboardList, fields: [] },
+];
+
+// environment以外の全フィールド（進捗バー計算用）
+const assessmentFields = [
+    'serviceHistory', 'healthStatus', 'pastHistory', 'skinCondition', 'oralHygiene', 'fluidIntake',
+    'adlTransfer', 'adlEating', 'adlToileting', 'adlBathing', 'adlDressing',
+    'iadlCooking', 'iadlShopping', 'iadlMoney', 'medication',
+    'cognition', 'communication',
+    'socialParticipation', 'residence', 'familySituation', 'maltreatmentRisk',
+] as const;
+
 export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
     const [activeTab, setActiveTab] = useState('health');
-    
+
     // Logic Engines
     const suggestions = useMemo(() => getCareManagementSuggestions(data), [data]);
 
@@ -132,7 +166,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
     const [aiUpdatedFields, setAiUpdatedFields] = useState<string[]>([]);
     // v1.2.3 Update: Set Initial Advice
     const [coPilotAdvice, setCoPilotAdvice] = useState<string[]>(INITIAL_ADVICE);
-    
+
     // Phase 5: Interval Setting (null = manual, number = ms)
     // DEMO UPDATE: Default to 30s for better first impression
     const [autoAnalysisInterval, setAutoAnalysisInterval] = useState<number | null>(30000);
@@ -145,24 +179,48 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
     const [isFinalizing, setIsFinalizing] = useState(false);
     const [generatedText, setGeneratedText] = useState<string | null>(null);
     const [isCopied, setIsCopied] = useState(false); // New: Feedback state for copy button
-    
+
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
     const chunksRef = useRef<BlobPart[]>([]);
     const intervalIdRef = useRef<number | null>(null);
-    
+
     // Critical for Phase 5: Fix Stale Closure in Interval
     const latestDataRef = useRef(data);
     useEffect(() => { latestDataRef.current = data; }, [data]);
-    
+
     const isRecordingRef = useRef(isRecording);
     useEffect(() => { isRecordingRef.current = isRecording; }, [isRecording]);
-    
+
     const autoAnalysisIntervalRef = useRef(autoAnalysisInterval);
     useEffect(() => { autoAnalysisIntervalRef.current = autoAnalysisInterval; }, [autoAnalysisInterval]);
-    
+
     // New: Keep track of summary for context injection
     const generatedTextRef = useRef(generatedText);
     useEffect(() => { generatedTextRef.current = generatedText; }, [generatedText]);
+
+    // 進捗計算
+    const progressInfo = useMemo(() => {
+        const filled = assessmentFields.filter((f) => data[f as keyof AssessmentData]?.trim()).length;
+        const total = assessmentFields.length;
+        const percent = Math.round((filled / total) * 100);
+        return { filled, total, percent };
+    }, [data]);
+
+    // タブ別未入力数
+    const tabEmptyCounts = useMemo(() => {
+        const counts: Record<string, number> = {};
+        for (const tab of tabDefinitions) {
+            if (tab.id === 'summary') {
+                counts[tab.id] = 0;
+                continue;
+            }
+            counts[tab.id] = tab.fields.filter((f) => {
+                if (f === 'environment') return false; // 特記事項は除外
+                return !data[f as keyof AssessmentData]?.trim();
+            }).length;
+        }
+        return counts;
+    }, [data]);
 
     // Debug Logger
     const logDebug = (action: string, payload: any) => {
@@ -185,7 +243,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
 
     // Handle AI Analysis Result
     const handleAnalysisResult = (result: any) => {
-        logDebug('AnalysisResultReceived', { 
+        logDebug('AnalysisResultReceived', {
             summaryLength: result.summary?.length || 0,
             fieldsUpdated: Object.keys(result.structuredData).length
         });
@@ -203,7 +261,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 updatedKeys.push(key);
             }
         });
-        
+
         setAiUpdatedFields(prev => [...Array.from(new Set([...prev, ...updatedKeys]))]);
 
         // 3. Update Co-pilot Advice
@@ -226,25 +284,25 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
             mediaRecorder.ondataavailable = async (e) => {
                 if (e.data.size > 0) {
                     chunksRef.current.push(e.data);
-                    
+
                     // Phase 5: Real-time Analysis logic
                     if (autoAnalysisIntervalRef.current && isRecordingRef.current) {
                         setIsProcessing(true);
                         const blobSize = chunksRef.current.reduce((acc: number, chunk: any) => acc + chunk.size, 0);
                         const sizeKB = (blobSize / 1024).toFixed(2);
-                        
+
                         logDebug('IntervalAnalysisStart', { blobSize: `${sizeKB} KB` });
 
                         // Create Blob from current session chunks
                         const currentSessionBlob = new Blob(chunksRef.current, { type: 'audio/webm' });
-                        
+
                         try {
                             // v1.2.1: Pass isFinal=false for interval analysis
                             // Phase 6: Pass currentSummary for context
                             const result = await analyzeAssessmentConversation(
-                                currentSessionBlob, 
-                                latestDataRef.current, 
-                                false, 
+                                currentSessionBlob,
+                                latestDataRef.current,
+                                false,
                                 generatedTextRef.current || ""
                             );
                             handleAnalysisResult(result);
@@ -264,8 +322,8 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 try {
                     // v1.2.1: Pass isFinal=true for stop analysis
                     const result = await analyzeAssessmentConversation(
-                        audioBlob, 
-                        latestDataRef.current, 
+                        audioBlob,
+                        latestDataRef.current,
                         true,
                          generatedTextRef.current || ""
                     );
@@ -277,7 +335,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                     setIsFinalizing(false);
                     setHasRecorded(true); // Mark as having recorded
                 }
-                
+
                 stream.getTracks().forEach(track => track.stop());
                 if (intervalIdRef.current) {
                     clearInterval(intervalIdRef.current);
@@ -285,10 +343,10 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 }
             };
 
-            mediaRecorder.start(); 
+            mediaRecorder.start();
             setIsRecording(true);
             setIsFinalizing(false);
-            
+
             // Reset state only if NOT resuming
             if (!resume) {
                 setGeneratedText(null);
@@ -330,23 +388,15 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
             const current = data.environment || '';
             const separator = current ? '\n\n' : '';
             onChange('environment', current + separator + generatedText);
-            
+
             // Feedback Logic
             setIsCopied(true);
             setTimeout(() => setIsCopied(false), 2000);
-            
+
             // UX Improvement: Automatically switch to the tab where "Environment" field exists
             setActiveTab('social');
         }
     };
-
-    const tabs = [
-        { id: 'health', label: '基本・健康', icon: Activity },
-        { id: 'adl', label: '生活機能', icon: Home },
-        { id: 'mental', label: '認知・精神', icon: Brain },
-        { id: 'social', label: '社会・環境', icon: Users },
-        { id: 'summary', label: '全体サマリー', icon: ClipboardList },
-    ];
 
     const fieldLabels: {[key: string]: string} = {
         serviceHistory: '1. サービス利用状況',
@@ -396,7 +446,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                     <div className="flex flex-col items-end">
                         <div className="flex items-center gap-2 bg-white rounded-lg p-1 border border-blue-100">
                             <Clock className="w-3 h-3 text-stone-400 ml-1" />
-                            <select 
+                            <select
                                 className="text-xs font-bold text-stone-600 bg-transparent border-none focus:ring-0 p-1 pr-6 cursor-pointer"
                                 value={autoAnalysisInterval || ''}
                                 onChange={(e) => setAutoAnalysisInterval(e.target.value ? Number(e.target.value) : null)}
@@ -422,7 +472,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                         <>
                             {hasRecorded ? (
                                 <>
-                                    <button 
+                                    <button
                                         onClick={() => startRecording(true)} // Resume
                                         disabled={isFinalizing}
                                         className="flex-1 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-3 rounded-lg shadow-md active:scale-95 transition-all flex items-center justify-center gap-2 disabled:opacity-50"
@@ -430,7 +480,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                                         <PlayCircle className="w-5 h-5" />
                                         <span className="text-sm font-bold">続きから録音 (追記)</span>
                                     </button>
-                                    <button 
+                                    <button
                                         onClick={() => startRecording(false)} // New
                                         disabled={isFinalizing}
                                         className="flex-1 bg-white hover:bg-red-50 text-red-600 border border-red-200 px-4 py-3 rounded-lg shadow-sm active:scale-95 transition-all flex items-center justify-center gap-2 disabled:opacity-50"
@@ -440,7 +490,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                                     </button>
                                 </>
                             ) : (
-                                <button 
+                                <button
                                     onClick={() => startRecording(false)}
                                     disabled={isFinalizing}
                                     className="flex-1 bg-white hover:bg-blue-50 text-blue-700 border-2 border-blue-200 px-4 py-3 rounded-lg shadow-sm active:scale-95 transition-all flex items-center justify-center gap-2 disabled:opacity-50"
@@ -469,7 +519,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                                     </div>
                                 )}
                             </div>
-                            <button 
+                            <button
                                 onClick={stopRecording}
                                 className="bg-red-50 text-red-600 border-2 border-red-200 px-6 rounded-lg font-bold hover:bg-red-100 transition-colors flex items-center gap-2"
                             >
@@ -479,7 +529,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                         </div>
                     )}
                 </div>
-                
+
                 {/* UX Fix: Explicit Finalizing Feedback */}
                 {isFinalizing && (
                     <div className="w-full bg-indigo-600 text-white rounded-lg p-3 flex items-center justify-center gap-3 shadow-lg animate-in slide-in-from-top-1">
@@ -487,7 +537,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                         <span className="font-bold text-sm">AIが会話の最終分析を行っています。お待ちください...</span>
                     </div>
                 )}
-                
+
                 {autoAnalysisInterval && isRecording && (
                     <div className="w-full text-center">
                         <p className="text-[10px] text-stone-400">
@@ -504,7 +554,7 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                         <Sparkles className="w-4 h-4" />
                         <h5 className="font-bold text-xs">AI生成要約 (特記事項ドラフト)</h5>
                     </div>
-                    <textarea 
+                    <textarea
                         className="w-full p-3 bg-white border border-indigo-200 rounded-lg text-sm text-stone-900 focus:ring-2 focus:ring-indigo-500"
                         rows={4}
                         value={generatedText || ''}
@@ -513,12 +563,12 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                         placeholder={isFinalizing ? "解析中..." : ""}
                     />
                     <div className="flex justify-end gap-2 mt-2">
-                        <button 
+                        <button
                             onClick={handleApplyToTextarea}
-                            disabled={isProcessing || isFinalizing || !generatedText || isCopied} 
+                            disabled={isProcessing || isFinalizing || !generatedText || isCopied}
                             className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold rounded-lg shadow-sm transition-all ${isCopied ? 'bg-green-600 text-white hover:bg-green-700' : 'bg-indigo-600 text-white hover:bg-indigo-700'} disabled:bg-stone-400 disabled:cursor-not-allowed`}
                         >
-                            {isFinalizing ? <Loader2 className="w-3 h-3 animate-spin" /> : 
+                            {isFinalizing ? <Loader2 className="w-3 h-3 animate-spin" /> :
                              isCopied ? <Check className="w-4 h-4" /> : <ArrowDownCircle className="w-4 h-4" />}
                             {isFinalizing ? "最終解析待ち..." : isCopied ? "追記しました" : "特記事項へ追記"}
                         </button>
@@ -526,19 +576,42 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 </div>
             )}
 
+            {/* 進捗バー */}
+            <div className="bg-white rounded-lg border border-stone-200 p-3">
+                <div className="flex items-center justify-between mb-2">
+                    <span className="text-sm font-bold text-stone-700">入力進捗</span>
+                    <span className="text-sm font-bold text-stone-600">
+                        {progressInfo.filled}/{progressInfo.total}項目 ({progressInfo.percent}%)
+                    </span>
+                </div>
+                <div className="w-full bg-stone-200 rounded-full h-2.5">
+                    <div
+                        className={`h-2.5 rounded-full transition-all duration-500 ${
+                            progressInfo.percent === 100 ? 'bg-green-500' : progressInfo.percent >= 50 ? 'bg-blue-500' : 'bg-amber-500'
+                        }`}
+                        style={{ width: `${progressInfo.percent}%` }}
+                    ></div>
+                </div>
+            </div>
+
             {/* Tab Navigation */}
             <div className="flex bg-stone-100 p-1 rounded-lg overflow-x-auto no-scrollbar">
-                {tabs.map((tab) => (
+                {tabDefinitions.map((tab) => (
                     <button
                         key={tab.id}
                         onClick={() => setActiveTab(tab.id)}
                         className={`
-                            flex-1 flex items-center justify-center gap-2 py-2 px-3 rounded-md text-sm font-bold whitespace-nowrap transition-all
+                            flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-md text-sm font-bold whitespace-nowrap transition-all relative
                             ${activeTab === tab.id ? 'bg-white text-blue-600 shadow-sm' : 'text-stone-500 hover:text-stone-700'}
                         `}
                     >
                         <tab.icon className="w-4 h-4" />
                         {tab.label}
+                        {tabEmptyCounts[tab.id] > 0 && (
+                            <span className="ml-1 bg-amber-100 text-amber-700 text-[10px] font-bold rounded-full w-5 h-5 flex items-center justify-center border border-amber-200">
+                                {tabEmptyCounts[tab.id]}
+                            </span>
+                        )}
                     </button>
                 ))}
             </div>
@@ -548,58 +621,64 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 {activeTab === 'health' && (
                     <div className="animate-in fade-in duration-200">
                         <h3 className="text-lg font-bold text-stone-800 mb-4 border-b pb-2">基本情報・健康状態</h3>
-                        
-                        <QuickOptions 
+
+                        <QuickOptions
                             label="1. サービス利用状況"
                             selected={data.serviceHistory}
                             onSelect={(val) => onChange('serviceHistory', val)}
                             options={["利用なし", "介護保険のみ利用中", "医療・障害併用", "自費サービス利用"]}
                             placeholder="現在のサービス利用状況を入力..."
                             isAiUpdated={aiUpdatedFields.includes('serviceHistory')}
+                            isEmpty={!data.serviceHistory?.trim()}
                         />
 
-                        <QuickOptions 
-                            label="2. 健康状態" 
-                            selected={data.healthStatus} 
-                            onSelect={(val) => onChange('healthStatus', val)} 
+                        <QuickOptions
+                            label="2. 健康状態"
+                            selected={data.healthStatus}
+                            onSelect={(val) => onChange('healthStatus', val)}
                             options={['安定している', '定期的な通院が必要', '体調変動が大きい', '終末期・重篤']}
                             placeholder="現在の健康状態や予後について..."
                             isAiUpdated={aiUpdatedFields.includes('healthStatus')}
+                            isEmpty={!data.healthStatus?.trim()}
                         />
-                        <QuickOptions 
-                            label="3. 既往歴" 
-                            selected={data.pastHistory} 
-                            onSelect={(val) => onChange('pastHistory', val)} 
+                        <QuickOptions
+                            label="3. 既往歴"
+                            selected={data.pastHistory}
+                            onSelect={(val) => onChange('pastHistory', val)}
                             options={['特になし', '脳血管疾患', '心疾患', '骨折', '認知症']}
                             placeholder="発症時期や後遺症の詳細..."
                             isAiUpdated={aiUpdatedFields.includes('pastHistory')}
+                            isEmpty={!data.pastHistory?.trim()}
                         />
-                        
-                        <QuickOptions 
+
+                        <QuickOptions
                             label="4. 皮膚・褥瘡"
                             selected={data.skinCondition}
                             onSelect={(val) => onChange('skinCondition', val)}
                             options={["問題なし", "乾燥・痒みあり", "褥瘡・発赤あり", "医療処置中"]}
                             placeholder="皮膚の状態、褥瘡のリスク..."
                             isAiUpdated={aiUpdatedFields.includes('skinCondition')}
+                            isEmpty={!data.skinCondition?.trim()}
                         />
 
-                        <QuickOptions 
+                        <QuickOptions
                             label="5. 口腔衛生"
                             selected={data.oralHygiene}
                             onSelect={(val) => onChange('oralHygiene', val)}
                             options={["問題なし", "歯科受診が必要", "義歯不適合", "咀嚼・嚥下困難"]}
                             placeholder="口腔ケアの状況、歯科通院の必要性..."
                             isAiUpdated={aiUpdatedFields.includes('oralHygiene')}
+                            isEmpty={!data.oralHygiene?.trim()}
                         />
 
-                        <QuickOptions 
+                        <QuickOptions
                             label="6. 水分摂取"
                             selected={data.fluidIntake}
                             onSelect={(val) => onChange('fluidIntake', val)}
                             options={["十分摂取", "意識して摂取中", "不足気味", "制限あり(医師指示)"]}
                             placeholder="1日の水分量、摂取方法..."
                             isAiUpdated={aiUpdatedFields.includes('fluidIntake')}
+                            isEmpty={!data.fluidIntake?.trim()}
                         />
                     </div>
                 )}
@@ -607,84 +686,93 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 {activeTab === 'adl' && (
                     <div className="animate-in fade-in duration-200">
                         <h3 className="text-lg font-bold text-stone-800 mb-4 border-b pb-2">生活機能 (ADL/IADL)</h3>
-                        
+
                         <div className="mb-6">
                             <h4 className="font-bold text-blue-800 text-sm mb-2 bg-blue-50 p-2 rounded">ADL (起居・身体動作)</h4>
-                            <QuickOptions 
-                                label="7. 移動・移乗" 
-                                selected={data.adlTransfer} 
-                                onSelect={(val) => onChange('adlTransfer', val)} 
+                            <QuickOptions
+                                label="7. 移動・移乗"
+                                selected={data.adlTransfer}
+                                onSelect={(val) => onChange('adlTransfer', val)}
                                 options={['自立', '見守りが必要', '一部介助', '全介助']}
                                 placeholder="寝返り、起き上がり、歩行状態..."
                                 isAiUpdated={aiUpdatedFields.includes('adlTransfer')}
+                                isEmpty={!data.adlTransfer?.trim()}
                             />
-                            <QuickOptions 
-                                label="8. 食事" 
-                                selected={data.adlEating} 
-                                onSelect={(val) => onChange('adlEating', val)} 
+                            <QuickOptions
+                                label="8. 食事"
+                                selected={data.adlEating}
+                                onSelect={(val) => onChange('adlEating', val)}
                                 options={['自立', '見守り・セッティング', '一部介助', '全介助']}
                                 placeholder="摂取動作、食事形態..."
                                 isAiUpdated={aiUpdatedFields.includes('adlEating')}
+                                isEmpty={!data.adlEating?.trim()}
                             />
-                            <QuickOptions 
-                                label="9. 排泄" 
-                                selected={data.adlToileting} 
-                                onSelect={(val) => onChange('adlToileting', val)} 
+                            <QuickOptions
+                                label="9. 排泄"
+                                selected={data.adlToileting}
+                                onSelect={(val) => onChange('adlToileting', val)}
                                 options={['自立', 'ポータブルトイレ使用', 'オムツ使用(介助)', '全介助']}
                                 placeholder="トイレ移動、後始末、失敗の有無..."
                                 isAiUpdated={aiUpdatedFields.includes('adlToileting')}
+                                isEmpty={!data.adlToileting?.trim()}
                             />
-                            <QuickOptions 
-                                label="10. 入浴" 
-                                selected={data.adlBathing} 
-                                onSelect={(val) => onChange('adlBathing', val)} 
+                            <QuickOptions
+                                label="10. 入浴"
+                                selected={data.adlBathing}
+                                onSelect={(val) => onChange('adlBathing', val)}
                                 options={['自立', '見守り', '一部介助', '全介助・清拭']}
                                 placeholder="洗身、洗髪、浴槽出入り..."
                                 isAiUpdated={aiUpdatedFields.includes('adlBathing')}
+                                isEmpty={!data.adlBathing?.trim()}
                             />
-                            <QuickOptions 
+                            <QuickOptions
                                 label="11. 衣服着脱"
                                 selected={data.adlDressing}
                                 onSelect={(val) => onChange('adlDressing', val)}
                                 options={["自立", "ボタン等一部介助", "着脱全介助", "季節に合わない"]}
                                 placeholder="整容、更衣の手順、手指機能..."
                                 isAiUpdated={aiUpdatedFields.includes('adlDressing')}
+                                isEmpty={!data.adlDressing?.trim()}
                             />
                         </div>
 
                         <div>
                             <h4 className="font-bold text-blue-800 text-sm mb-2 bg-blue-50 p-2 rounded">IADL (手段的日常生活動作)</h4>
-                            <QuickOptions 
-                                label="12. 調理・家事" 
-                                selected={data.iadlCooking} 
-                                onSelect={(val) => onChange('iadlCooking', val)} 
+                            <QuickOptions
+                                label="12. 調理・家事"
+                                selected={data.iadlCooking}
+                                onSelect={(val) => onChange('iadlCooking', val)}
                                 options={['自立', '一部困難', '全般的に困難', '実施していない']}
                                 placeholder="調理、洗濯、掃除の状況..."
                                 isAiUpdated={aiUpdatedFields.includes('iadlCooking')}
+                                isEmpty={!data.iadlCooking?.trim()}
                             />
-                            <QuickOptions 
-                                label="13. 買い物" 
-                                selected={data.iadlShopping} 
-                                onSelect={(val) => onChange('iadlShopping', val)} 
+                            <QuickOptions
+                                label="13. 買い物"
+                                selected={data.iadlShopping}
+                                onSelect={(val) => onChange('iadlShopping', val)}
                                 options={['自立', '付き添いが必要', '代行が必要', '困難']}
                                 placeholder="外出頻度、重い物の購入..."
                                 isAiUpdated={aiUpdatedFields.includes('iadlShopping')}
+                                isEmpty={!data.iadlShopping?.trim()}
                             />
-                            <QuickOptions 
-                                label="14. 金銭管理" 
-                                selected={data.iadlMoney} 
-                                onSelect={(val) => onChange('iadlMoney', val)} 
+                            <QuickOptions
+                                label="14. 金銭管理"
+                                selected={data.iadlMoney}
+                                onSelect={(val) => onChange('iadlMoney', val)}
                                 options={['自立', '家族が支援', '後見人等が管理', '困難']}
                                 placeholder="日常の金銭管理、預貯金管理..."
                                 isAiUpdated={aiUpdatedFields.includes('iadlMoney')}
+                                isEmpty={!data.iadlMoney?.trim()}
                             />
-                            <QuickOptions 
-                                label="15. 服薬管理" 
-                                selected={data.medication} 
-                                onSelect={(val) => onChange('medication', val)} 
+                            <QuickOptions
+                                label="15. 服薬管理"
+                                selected={data.medication}
+                                onSelect={(val) => onChange('medication', val)}
                                 options={['自立', 'カレンダー等で自立', '声掛けが必要', '管理困難']}
                                 placeholder="飲み忘れ、セット状況..."
                                 isAiUpdated={aiUpdatedFields.includes('medication')}
+                                isEmpty={!data.medication?.trim()}
                             />
                         </div>
                     </div>
@@ -693,21 +781,23 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 {activeTab === 'mental' && (
                     <div className="animate-in fade-in duration-200">
                         <h3 className="text-lg font-bold text-stone-800 mb-4 border-b pb-2">認知・精神・意思疎通</h3>
-                        <QuickOptions 
-                            label="16. 認知機能" 
-                            selected={data.cognition} 
-                            onSelect={(val) => onChange('cognition', val)} 
+                        <QuickOptions
+                            label="16. 認知機能"
+                            selected={data.cognition}
+                            onSelect={(val) => onChange('cognition', val)}
                             options={['自立', '年齢相応の物忘れ', '認知症の疑い', '認知症(診断済)']}
                             placeholder="記憶力、見当識、BPSDの有無..."
                             isAiUpdated={aiUpdatedFields.includes('cognition')}
+                            isEmpty={!data.cognition?.trim()}
                         />
-                        <QuickOptions 
-                            label="17. 意思疎通" 
-                            selected={data.communication} 
-                            onSelect={(val) => onChange('communication', val)} 
+                        <QuickOptions
+                            label="17. 意思疎通"
+                            selected={data.communication}
+                            onSelect={(val) => onChange('communication', val)}
                             options={['良好', '聞き返しが必要', '意思伝達困難', '反応なし']}
                             placeholder="視力、聴力、構音障害..."
                             isAiUpdated={aiUpdatedFields.includes('communication')}
+                            isEmpty={!data.communication?.trim()}
                         />
                     </div>
                 )}
@@ -715,41 +805,45 @@ export const TouchAssessment: React.FC<Props> = ({ data, onChange }) => {
                 {activeTab === 'social' && (
                     <div className="animate-in fade-in duration-200">
                         <h3 className="text-lg font-bold text-stone-800 mb-4 border-b pb-2">社会・環境</h3>
-                        <QuickOptions 
-                            label="18. 社会参加" 
-                            selected={data.socialParticipation} 
-                            onSelect={(val) => onChange('socialParticipation', val)} 
+                        <QuickOptions
+                            label="18. 社会参加"
+                            selected={data.socialParticipation}
+                            onSelect={(val) => onChange('socialParticipation', val)}
                             options={['積極的', '週1回程度', '閉じこもりがち', '交流拒否']}
                             placeholder="近所付き合い、趣味活動、役割..."
                             isAiUpdated={aiUpdatedFields.includes('socialParticipation')}
+                            isEmpty={!data.socialParticipation?.trim()}
                         />
-                        <QuickOptions 
-                            label="19. 居住環境" 
-                            selected={data.residence} 
-                            onSelect={(val) => onChange('residence', val)} 
+                        <QuickOptions
+                            label="19. 居住環境"
+                            selected={data.residence}
+                            onSelect={(val) => onChange('residence', val)}
                             options={['問題なし', '段差あり(改修済)', '段差等の課題あり', '著しく不衛生']}
                             placeholder="家屋状況、住宅改修の必要性..."
                             isAiUpdated={aiUpdatedFields.includes('residence')}
+                            isEmpty={!data.residence?.trim()}
                         />
-                        <QuickOptions 
-                            label="20. 家族状況" 
-                            selected={data.familySituation} 
-                            onSelect={(val) => onChange('familySituation', val)} 
+                        <QuickOptions
+                            label="20. 家族状況"
+                            selected={data.familySituation}
+                            onSelect={(val) => onChange('familySituation', val)}
                             options={['同居家族が主介護', '独居・近隣に支援者', '独居・支援者なし', '老老介護']}
                             placeholder="キーパーソン、介護力、介護疲れ..."
                             isAiUpdated={aiUpdatedFields.includes('familySituation')}
+                            isEmpty={!data.familySituation?.trim()}
                         />
-                        <QuickOptions 
-                            label="21. 虐待リスク" 
-                            selected={data.maltreatmentRisk} 
-                            onSelect={(val) => onChange('maltreatmentRisk', val)} 
+                        <QuickOptions
+                            label="21. 虐待リスク"
+                            selected={data.maltreatmentRisk}
+                            onSelect={(val) => onChange('maltreatmentRisk', val)}
                             options={['兆候なし', '介護疲れの兆候', '経済的虐待の懸念', '身体的虐待の懸念']}
                             placeholder="養護者による虐待の兆候..."
                             isAiUpdated={aiUpdatedFields.includes('maltreatmentRisk')}
+                            isEmpty={!data.maltreatmentRisk?.trim()}
                         />
                         <div className="mt-6">
                             <label className="block text-sm font-bold text-stone-700 mb-2">22. 特記事項・総合的課題</label>
-                            <textarea 
+                            <textarea
                                 className="w-full p-4 border border-stone-200 rounded-lg h-32 bg-stone-50 focus:bg-white transition-colors"
                                 value={data.environment}
                                 onChange={e => onChange('environment', e.target.value)}

--- a/components/records/SupportRecordList.tsx
+++ b/components/records/SupportRecordList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { listSupportRecords, deleteSupportRecord, type SupportRecordDocument } from '../../services/firebase';
 import type { SupportRecordType } from '../../types';
 
@@ -29,6 +29,8 @@ const recordTypeColors: Record<SupportRecordType, string> = {
   other: 'bg-gray-100 text-gray-600',
 };
 
+const allRecordTypes = Object.keys(recordTypeLabels) as SupportRecordType[];
+
 export const SupportRecordList: React.FC<SupportRecordListProps> = ({
   userId,
   clientId,
@@ -38,6 +40,13 @@ export const SupportRecordList: React.FC<SupportRecordListProps> = ({
   const [records, setRecords] = useState<SupportRecordDocument[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // フィルタ状態
+  const [showFilters, setShowFilters] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [selectedTypes, setSelectedTypes] = useState<SupportRecordType[]>([]);
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
 
   useEffect(() => {
     loadRecords();
@@ -80,6 +89,52 @@ export const SupportRecordList: React.FC<SupportRecordListProps> = ({
     });
   };
 
+  const toggleTypeFilter = (type: SupportRecordType) => {
+    setSelectedTypes((prev) =>
+      prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type]
+    );
+  };
+
+  const clearFilters = () => {
+    setSearchText('');
+    setSelectedTypes([]);
+    setDateFrom('');
+    setDateTo('');
+  };
+
+  const hasActiveFilters = searchText || selectedTypes.length > 0 || dateFrom || dateTo;
+
+  const filteredRecords = useMemo(() => {
+    return records.filter((record) => {
+      // テキスト検索（内容・結果・相手先）
+      if (searchText) {
+        const lower = searchText.toLowerCase();
+        const matchContent = record.content?.toLowerCase().includes(lower);
+        const matchResult = record.result?.toLowerCase().includes(lower);
+        const matchCounterpart = record.counterpart?.toLowerCase().includes(lower);
+        if (!matchContent && !matchResult && !matchCounterpart) return false;
+      }
+
+      // 記録タイプフィルタ
+      if (selectedTypes.length > 0 && !selectedTypes.includes(record.recordType)) {
+        return false;
+      }
+
+      // 日付範囲フィルタ
+      if (dateFrom || dateTo) {
+        const recordDate = record.recordDate.toDate();
+        if (dateFrom && recordDate < new Date(dateFrom)) return false;
+        if (dateTo) {
+          const toDate = new Date(dateTo);
+          toDate.setHours(23, 59, 59, 999);
+          if (recordDate > toDate) return false;
+        }
+      }
+
+      return true;
+    });
+  }, [records, searchText, selectedTypes, dateFrom, dateTo]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center p-8">
@@ -108,18 +163,123 @@ export const SupportRecordList: React.FC<SupportRecordListProps> = ({
       {/* ヘッダー */}
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-bold text-gray-900">支援経過記録（第5表）</h2>
-        {onAdd && (
-          <button
-            onClick={onAdd}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 flex items-center gap-2"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
-            新規記録
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          {records.length > 0 && (
+            <button
+              onClick={() => setShowFilters(!showFilters)}
+              className={`px-3 py-2 text-sm rounded-md border transition-colors flex items-center gap-1 ${
+                showFilters || hasActiveFilters
+                  ? 'bg-blue-50 text-blue-700 border-blue-300'
+                  : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+              </svg>
+              検索・フィルタ
+              {hasActiveFilters && (
+                <span className="bg-blue-600 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
+                  {(searchText ? 1 : 0) + (selectedTypes.length > 0 ? 1 : 0) + (dateFrom || dateTo ? 1 : 0)}
+                </span>
+              )}
+            </button>
+          )}
+          {onAdd && (
+            <button
+              onClick={onAdd}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 flex items-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              新規記録
+            </button>
+          )}
+        </div>
       </div>
+
+      {/* フィルタパネル */}
+      {showFilters && (
+        <div className="bg-gray-50 rounded-lg border border-gray-200 p-4 space-y-3">
+          {/* テキスト検索 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">キーワード検索</label>
+            <input
+              type="text"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              placeholder="内容・結果・相手先で検索..."
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {/* 記録タイプフィルタ */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">記録タイプ</label>
+            <div className="flex flex-wrap gap-2">
+              {allRecordTypes.map((type) => (
+                <button
+                  key={type}
+                  onClick={() => toggleTypeFilter(type)}
+                  className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                    selectedTypes.includes(type)
+                      ? `${recordTypeColors[type]} border-current`
+                      : 'bg-white text-gray-500 border-gray-300 hover:bg-gray-100'
+                  }`}
+                >
+                  {recordTypeLabels[type]}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 日付範囲 */}
+          <div className="flex gap-3 items-end">
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">開始日</label>
+              <input
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <span className="pb-2 text-gray-400">〜</span>
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">終了日</label>
+              <input
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          {/* クリアボタン */}
+          {hasActiveFilters && (
+            <div className="flex justify-end">
+              <button
+                onClick={clearFilters}
+                className="text-sm text-gray-500 hover:text-gray-700 underline"
+              >
+                フィルタをクリア
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 結果件数 */}
+      {hasActiveFilters && (
+        <div className="text-sm text-gray-600">
+          {filteredRecords.length === 0 ? (
+            <span className="text-amber-600">条件に一致する記録がありません</span>
+          ) : (
+            <span>{records.length}件中 {filteredRecords.length}件を表示</span>
+          )}
+        </div>
+      )}
 
       {/* 記録一覧 */}
       {records.length === 0 ? (
@@ -134,9 +294,19 @@ export const SupportRecordList: React.FC<SupportRecordListProps> = ({
             </button>
           )}
         </div>
+      ) : filteredRecords.length === 0 && hasActiveFilters ? (
+        <div className="text-center py-8 text-gray-500">
+          <p>条件に一致する記録がありません</p>
+          <button
+            onClick={clearFilters}
+            className="mt-2 text-blue-600 hover:underline"
+          >
+            フィルタをクリア
+          </button>
+        </div>
       ) : (
         <div className="space-y-3">
-          {records.map((record) => (
+          {filteredRecords.map((record) => (
             <div
               key={record.id}
               className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow"


### PR DESCRIPTION
## Summary

- **支援経過記録の検索・フィルタ**: テキスト検索（内容・結果・相手先）、記録タイプ別フィルタ、日付範囲フィルタを追加。折りたたみ式パネルで結果件数を表示
- **アセスメント未入力ハイライト**: 入力進捗バー（パーセント表示）、未入力フィールドのamber色ハイライト＋「未入力」バッジ、タブ別未入力数バッジ
- **モニタリング定型文テンプレート**: 全体所見/健康変化/生活状況/サービス利用/次回アクションの5フィールドに定型文ボタンを追加（クリックで既存テキストに追記）
- **ROADMAP.md更新**: 完了済みタスクの反映、コンポーネント構成図の最新化

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `components/records/SupportRecordList.tsx` | 検索・フィルタUI追加 |
| `components/assessment/TouchAssessment.tsx` | 進捗バー・未入力ハイライト追加 |
| `components/monitoring/MonitoringDiffView.tsx` | 定型文テンプレート追加 |
| `docs/ROADMAP.md` | ステータス更新・構成図最新化 |

## Test plan

- [ ] 支援経過タブでキーワード検索・タイプフィルタ・日付範囲フィルタが動作すること
- [ ] フィルタ結果が0件の場合「フィルタをクリア」ボタンが表示されること
- [ ] アセスメントタブで進捗バーが入力に応じて更新されること
- [ ] 未入力フィールドにamber色の「未入力」バッジが表示されること
- [ ] タブボタンに未入力数バッジが表示されること
- [ ] モニタリングタブで定型文ボタンをクリックしてテキストが追記されること
- [ ] `npm run build` でビルドエラーなし（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)