### PR TITLE
feat: Firebase Emulatorローカル開発環境を整備

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_USE_EMULATOR=true

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { User, onAuthStateChanged } from 'firebase/auth';
-import { auth, signInWithGoogle, signOutUser } from '../services/firebase';
+import { auth, signInWithGoogle, signOutUser, signInAsTestUser, isEmulator } from '../services/firebase';
 
 interface AuthContextType {
   user: User | null;
@@ -26,6 +26,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     return () => unsubscribe();
   }, []);
+
+  // Emulator時は自動ログイン
+  useEffect(() => {
+    if (isEmulator && !user && !loading) {
+      signInAsTestUser();
+    }
+  }, [user, loading]);
 
   const login = async () => {
     setError(null);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "dev:emulator": "firebase emulators:start",
+    "dev:seed": "npx tsx scripts/seed.ts test-user-uid --emulator",
     "emulators": "firebase emulators:start",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -7,23 +7,8 @@
  */
 
 import { AssessmentData } from '../types';
-import { analyzeAssessment as callAnalyzeAssessment } from './firebase';
-import { getFunctions, httpsCallable } from 'firebase/functions';
-import { initializeApp, getApps } from 'firebase/app';
-
-// Firebase設定（firebase.tsと共有）
-const firebaseConfig = {
-  apiKey: 'AIzaSyBIXVu-eGU5HuYyahCh9y8pL5pniGmwfJc',
-  authDomain: 'caremanager-ai-copilot-486212.firebaseapp.com',
-  projectId: 'caremanager-ai-copilot-486212',
-  storageBucket: 'caremanager-ai-copilot-486212.firebasestorage.app',
-  messagingSenderId: '405962110931',
-  appId: '1:405962110931:web:aeffd8c49575549b05e126',
-};
-
-// Firebase初期化（まだ初期化されていない場合のみ）
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
-const functions = getFunctions(app, 'asia-northeast1');
+import { analyzeAssessment as callAnalyzeAssessment, functions } from './firebase';
+import { httpsCallable } from 'firebase/functions';
 
 // Cloud Functions の呼び出し設定
 const refineCareGoalFn = httpsCallable<{ currentGoal: string }, { refinedGoal: string; wasRefined: boolean }>(


### PR DESCRIPTION
## Summary

- `VITE_USE_EMULATOR` 環境変数でEmulator自動接続（Auth/Firestore/Functions）
- `geminiService.ts` の重複Firebase config削除（DRY修正）
- Auth Emulator接続時のテストユーザー自動ログイン（Googleログイン不要）
- `scripts/seed.ts` に `--emulator` フラグ対応追加
- `dev:emulator` / `dev:seed` npmスクリプト追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `.env.development` | **新規**: `VITE_USE_EMULATOR=true` |
| `services/firebase.ts` | Emulator接続 + `isEmulator` export + `signInAsTestUser()` |
| `services/geminiService.ts` | DRY修正: 重複Firebase config削除 |
| `contexts/AuthContext.tsx` | Emulator時の自動ログイン |
| `scripts/seed.ts` | `--emulator` フラグ対応 |
| `package.json` | `dev:emulator`, `dev:seed` スクリプト追加 |

## 開発フロー

```bash
# ターミナル1: Emulator起動
npm run dev:emulator

# ターミナル2: フロントエンド起動（自動でEmulator接続）
npm run dev

# ターミナル3（初回のみ）: シードデータ投入
npm run dev:seed
```

## Test plan

- [ ] `npm run dev:emulator` でEmulator起動（Auth:9099, Firestore:8080, Functions:5001）
- [ ] `npm run dev` でVite起動 → ブラウザで自動ログインされることを確認
- [ ] `npm run dev:seed` でシードデータ投入 → 利用者一覧が表示されること
- [ ] Emulator UI（`http://localhost:4000`）でデータ・ユーザー確認
- [ ] `npm run build` で本番ビルドが壊れていないこと（✅ CI確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)