### PR TITLE
fix: サイレント失敗エラーハンドリング修正 + Firestore旧パス削除

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -150,6 +150,7 @@ export default function App() {
       setAssessmentList(list);
     } catch (error) {
       console.error('Failed to load assessments:', error);
+      setSaveMessage({ type: 'error', text: 'アセスメント一覧の読み込みに失敗しました' });
     } finally {
       setIsLoadingList(false);
     }
@@ -310,6 +311,7 @@ export default function App() {
       }
     } catch (error: any) {
       console.error('AI Refine Error:', error);
+      setSaveMessage({ type: 'error', text: 'AI推敲に失敗しました。再度お試しください' });
     } finally {
       setAiLoading(false);
     }
@@ -329,6 +331,7 @@ export default function App() {
         });
     } catch (error) {
         console.error("Drafting Error:", error);
+        setSaveMessage({ type: 'error', text: 'AIケアプラン作成に失敗しました。再度お試しください' });
     } finally {
         setDraftingLoading(false);
     }

--- a/components/meeting/ServiceMeetingForm.tsx
+++ b/components/meeting/ServiceMeetingForm.tsx
@@ -43,6 +43,7 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
 }) => {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // 基本情報
   const [meetingDate, setMeetingDate] = useState(
@@ -105,6 +106,7 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to load existing record:', error);
+      setLoadError('既存レコードの読み込みに失敗しました');
     } finally {
       setLoading(false);
     }
@@ -209,6 +211,12 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
   return (
     <div className="space-y-6 p-4 max-w-4xl mx-auto">
       <h2 className="text-xl font-bold text-gray-900">サービス担当者会議記録（第4表）</h2>
+
+      {loadError && (
+        <div className="p-3 bg-red-50 text-red-700 border border-red-200 rounded-lg text-sm">
+          {loadError}
+        </div>
+      )}
 
       {/* 会議基本情報 */}
       <section className="bg-white rounded-lg shadow p-4">

--- a/components/meeting/ServiceMeetingList.tsx
+++ b/components/meeting/ServiceMeetingList.tsx
@@ -31,12 +31,14 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
   const [records, setRecords] = useState<ServiceMeetingRecordDocument[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     loadRecords();
   }, [userId, clientId, carePlanId]);
 
   const loadRecords = async () => {
+    setLoadError(null);
     setLoading(true);
     try {
       const list = carePlanId
@@ -45,6 +47,7 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
       setRecords(list);
     } catch (error) {
       console.error('Failed to load meeting records:', error);
+      setLoadError('会議記録の読み込みに失敗しました');
     } finally {
       setLoading(false);
     }
@@ -71,6 +74,20 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
       <div className="flex items-center justify-center p-8">
         <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
         <span className="ml-2 text-gray-600 text-sm">読み込み中...</span>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="p-4 bg-red-50 text-red-600 rounded-lg">
+        {loadError}
+        <button
+          onClick={loadRecords}
+          className="ml-2 underline hover:no-underline"
+        >
+          再読み込み
+        </button>
       </div>
     );
   }

--- a/components/monitoring/MonitoringDiffView.tsx
+++ b/components/monitoring/MonitoringDiffView.tsx
@@ -110,6 +110,7 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
 }) => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [initError, setInitError] = useState<string | null>(null);
   const [diffMode, setDiffMode] = useState(true);
   const [previousRecord, setPreviousRecord] = useState<MonitoringRecordDocument | null>(null);
 
@@ -179,6 +180,7 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
         }
       } catch (error) {
         console.error('Failed to initialize form:', error);
+        setInitError('フォームの初期化に失敗しました');
       } finally {
         setLoading(false);
       }
@@ -350,6 +352,12 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
           )}
         </div>
       </div>
+
+      {initError && (
+        <div className="p-3 bg-red-50 text-red-700 border border-red-200 rounded-lg text-sm">
+          {initError}
+        </div>
+      )}
 
       {/* 前回記録情報 */}
       {previousRecord && diffMode && (

--- a/components/monitoring/MonitoringForm.tsx
+++ b/components/monitoring/MonitoringForm.tsx
@@ -107,6 +107,7 @@ export const MonitoringForm: React.FC<MonitoringFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to load existing record:', error);
+      setSaveError('既存レコードの読み込みに失敗しました');
     } finally {
       setLoading(false);
     }

--- a/components/monitoring/MonitoringRecordList.tsx
+++ b/components/monitoring/MonitoringRecordList.tsx
@@ -31,12 +31,14 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
   const [records, setRecords] = useState<MonitoringRecordDocument[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     loadRecords();
   }, [userId, clientId, carePlanId]);
 
   const loadRecords = async () => {
+    setLoadError(null);
     setLoading(true);
     try {
       const list = carePlanId
@@ -45,6 +47,7 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
       setRecords(list);
     } catch (error) {
       console.error('Failed to load monitoring records:', error);
+      setLoadError('モニタリング記録の読み込みに失敗しました');
     } finally {
       setLoading(false);
     }
@@ -83,6 +86,20 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
       <div className="flex items-center justify-center p-8">
         <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
         <span className="ml-2 text-gray-600 text-sm">読み込み中...</span>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="p-4 bg-red-50 text-red-600 rounded-lg">
+        {loadError}
+        <button
+          onClick={loadRecords}
+          className="ml-2 underline hover:no-underline"
+        >
+          再読み込み
+        </button>
       </div>
     );
   }

--- a/components/records/SupportRecordForm.tsx
+++ b/components/records/SupportRecordForm.tsx
@@ -76,6 +76,7 @@ export const SupportRecordForm: React.FC<SupportRecordFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to load existing record:', error);
+      setError('既存レコードの読み込みに失敗しました');
     } finally {
       setLoading(false);
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -39,26 +39,6 @@ service cloud.firestore {
         }
       }
 
-      // 旧パス（後方互換・移行用）
-      match /assessments/{assessmentId} {
-        allow read, write: if isAuthenticated() && isOwner(userId);
-      }
-
-      match /carePlans/{planId} {
-        allow read, write: if isAuthenticated() && isOwner(userId);
-      }
-
-      match /monitoringRecords/{recordId} {
-        allow read, write: if isAuthenticated() && isOwner(userId);
-      }
-
-      match /supportRecords/{recordId} {
-        allow read, write: if isAuthenticated() && isOwner(userId);
-      }
-
-      match /serviceMeetingRecords/{recordId} {
-        allow read, write: if isAuthenticated() && isOwner(userId);
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- **9箇所のサイレント失敗**（`console.error`のみ）をユーザー通知付きエラーに変換
- **Firestore旧パス5件**（コード未参照）を`firestore.rules`から削除

## 変更詳細

| ファイル | 修正内容 |
|---------|---------|
| `App.tsx` | `loadAssessmentList` / `handleAiRefine` / `handleAiDrafting` の catch で既存 `setSaveMessage` を利用（3行追加） |
| `MonitoringForm.tsx` | `loadExistingRecord` catch で既存 `setSaveError` を利用（1行追加） |
| `SupportRecordForm.tsx` | `loadExistingRecord` catch で既存 `setError` を利用（1行追加） |
| `ServiceMeetingForm.tsx` | `loadError` state 追加 + フォーム先頭に赤バナー表示 |
| `MonitoringDiffView.tsx` | `initError` state 追加 + ヘッダー下に赤バナー表示 |
| `MonitoringRecordList.tsx` | `loadError` state 追加 + 再読み込みボタン付きエラーUI |
| `ServiceMeetingList.tsx` | 同上（`SupportRecordList` パターン準拠） |
| `firestore.rules` | 旧パス5件削除（20行削除）—コードから参照なし確認済み |

## 方針

- **既存パターン再利用**（最小変更）: state/UIの追加は既存コンポーネントのパターンに準拠
- `alert()` の統一は今回スコープ外（機能的に動作しているため別PRで対応）

## Test plan

- [x] `npm run build` — TypeScript コンパイルエラーなし
- [x] `npm test` — 11テストパス / 1スキップ
- [ ] Emulator手動確認（任意）: ネットワーク切断等でエラー発生させ、UIに通知が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)