### PR TITLE
feat: デモ環境1コマンド起動の実装 (#35)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "dev:emulator": "firebase emulators:start",
     "dev:seed": "npx tsx scripts/seed.ts test-user-uid --emulator",
+    "demo": "bash scripts/start-demo.sh",
     "emulators": "firebase emulators:start",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -50,6 +50,30 @@ function daysAgo(days: number) {
 async function seed() {
   console.log(`Seeding data for user: ${userId}`);
 
+  // Emulator環境：Auth EmulatorにUID固定のテストユーザーを作成
+  // （seed.tsのuserId引数と、signInAsTestUser()のUIDを一致させるため）
+  if (useEmulator) {
+    const PROJECT_ID = 'caremanager-ai-copilot-486212';
+    const res = await fetch(
+      `http://localhost:9099/emulator/v1/projects/${PROJECT_ID}/accounts`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          localId: userId,
+          email: 'test@example.com',
+          password: 'testpassword123',
+          emailVerified: true,
+        }),
+      }
+    );
+    const data = await res.json() as { error?: { message?: string } };
+    if (!res.ok && !data.error?.message?.includes('already exists')) {
+      throw new Error(`Auth Emulatorユーザー作成失敗: ${JSON.stringify(data)}`);
+    }
+    console.log(`  ✓ Auth Emulatorにテストユーザー作成 (uid: ${userId})`);
+  }
+
   // ============================================================
   // allowed_emails: パイロットユーザー許可リスト
   // ============================================================

--- a/scripts/start-demo.sh
+++ b/scripts/start-demo.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+echo "🎬 デモ環境を起動します..."
+
+# Emulatorをバックグラウンドで起動
+firebase emulators:start &
+EMULATOR_PID=$!
+
+# Ctrl+C / 終了時にEmulatorを停止
+trap "echo ''; echo '🛑 デモ環境を停止します...'; kill $EMULATOR_PID 2>/dev/null; exit" SIGINT SIGTERM
+
+echo "⏳ Emulator起動待ち..."
+until curl -sf http://localhost:9099 > /dev/null 2>&1; do
+  sleep 1
+done
+
+echo "🌱 シードデータを投入します..."
+npm run dev:seed
+
+echo "🚀 Viteを起動します ( http://localhost:5173 )"
+npm run dev
+
+# Vite終了後にEmulatorも停止
+kill $EMULATOR_PID 2>/dev/null


### PR DESCRIPTION
## Summary

- `npm run demo` 1コマンドでデモ環境が起動
- Auth EmulatorにUID固定（`test-user-uid`）のテストユーザーを作成し、ログイン画面をスキップ
- seed.ts の UID と `signInAsTestUser()` の UID 不一致バグを修正

## 変更ファイル

| ファイル | 変更内容 |
|---------|----------|
| `scripts/start-demo.sh` | Emulator起動→seed投入→Vite起動を一括実行 |
| `scripts/seed.ts` | Auth Emulatorへ localId 固定でテストユーザー作成 |
| `package.json` | `demo` スクリプト追加 |

## 動作確認手順

```bash
npm run demo
# → http://localhost:5173 でログインなしに利用者一覧が表示される
```

## Test plan

- [ ] `npm run demo` を実行
- [ ] Emulatorが起動しシードデータが投入される
- [ ] http://localhost:5173 でログイン画面なしに利用者一覧（田中花子・佐藤太郎・鈴木一郎）が表示される
- [ ] ケアプラン・モニタリング・支援経過の各画面が動作する
- [ ] Ctrl+C でEmulator・Viteが両方終了する

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)