### PR TITLE
feat: 管理者ロール・ホワイトリスト管理機能

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,7 @@ import { HospitalAdmissionSheetView } from './components/documents';
 import { ServiceMeetingForm, ServiceMeetingList } from './components/meeting';
 import { ClientListView, ClientForm, ClientContextBar } from './components/clients';
 import { DashboardView } from './components/dashboard';
+import { WhitelistManagement } from './components/admin';
 import { generateHospitalAdmissionSheet, UserBasicInfo, CareManagerInfo } from './utils/hospitalAdmissionSheet';
 
 // Updated Initial Assessment matching 23 Items Structure
@@ -55,7 +56,7 @@ const INITIAL_ASSESSMENT: AssessmentData = {
 type ClientViewMode = 'dashboard' | 'list' | 'form' | 'selected';
 
 export default function App() {
-  const { user, loading, logout, isDemoUser } = useAuth();
+  const { user, loading, logout, isDemoUser, isAdmin } = useAuth();
   const { consentStatus, saveConsent, isSaving: isConsentSaving, saveError: consentSaveError } = usePrivacyConsent(user?.uid ?? null);
   const { selectedClient, selectClient, clearSelectedClient } = useClient();
   const { showTour, completeTour, reopenTour } = useOnboarding();
@@ -123,6 +124,9 @@ export default function App() {
 
   // Demo Reset State
   const [isDemoResetting, setIsDemoResetting] = useState(false);
+
+  // Admin Whitelist Management State
+  const [showWhitelistManagement, setShowWhitelistManagement] = useState(false);
 
   // Dirty state tracking（未保存変更）
   const [dirtyTabs, setDirtyTabs] = useState<Set<string>>(new Set());
@@ -506,6 +510,14 @@ export default function App() {
         }}
       />
 
+      {/* Whitelist Management Modal (Admin only) */}
+      {isAdmin && (
+        <WhitelistManagement
+          isOpen={showWhitelistManagement}
+          onClose={() => setShowWhitelistManagement(false)}
+        />
+      )}
+
       {/* Menu Drawer */}
       <MenuDrawer
         isOpen={isMenuOpen}
@@ -520,6 +532,8 @@ export default function App() {
         onShowGuide={reopenTour}
         onShowHelp={() => setIsHelpOpen(true)}
         onShowPrivacyPolicy={() => setIsPrivacyPolicyOpen(true)}
+        isAdmin={isAdmin}
+        onWhitelistManagement={() => setShowWhitelistManagement(true)}
       />
 
       {/* Print Preview */}

--- a/components/admin/WhitelistManagement.tsx
+++ b/components/admin/WhitelistManagement.tsx
@@ -1,0 +1,240 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { X, Plus, Trash2, Loader2, Users, AlertCircle, Check, Mail } from 'lucide-react';
+import { listAllowedEmailsFn, manageAllowedEmailFn } from '../../services/firebase';
+import type { AllowedEmailEntry } from '../../services/firebase';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
+  const [emails, setEmails] = useState<AllowedEmailEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [newEmail, setNewEmail] = useState('');
+  const [newNote, setNewNote] = useState('');
+  const [isAdding, setIsAdding] = useState(false);
+  const [deletingEmail, setDeletingEmail] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const loadEmails = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const result = await listAllowedEmailsFn();
+      setEmails(result.data.emails);
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : '一覧取得に失敗しました';
+      setMessage({ type: 'error', text: errorMsg });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadEmails();
+      setMessage(null);
+      setNewEmail('');
+      setNewNote('');
+    }
+  }, [isOpen, loadEmails]);
+
+  // メッセージの自動消去
+  useEffect(() => {
+    if (message) {
+      const timer = setTimeout(() => setMessage(null), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [message]);
+
+  if (!isOpen) return null;
+
+  const handleAdd = async () => {
+    const trimmedEmail = newEmail.trim().toLowerCase();
+    if (!trimmedEmail) return;
+
+    setIsAdding(true);
+    setMessage(null);
+    try {
+      const result = await manageAllowedEmailFn({
+        action: 'add',
+        email: trimmedEmail,
+        note: newNote.trim() || undefined,
+      });
+      setMessage({ type: 'success', text: result.data.message });
+      setNewEmail('');
+      setNewNote('');
+      await loadEmails();
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : '追加に失敗しました';
+      setMessage({ type: 'error', text: errorMsg });
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleRemove = async (email: string) => {
+    if (!confirm(`${email} をアクセス許可リストから削除しますか？\nこのユーザーはログインできなくなります。`)) return;
+
+    setDeletingEmail(email);
+    setMessage(null);
+    try {
+      const result = await manageAllowedEmailFn({ action: 'remove', email });
+      setMessage({ type: 'success', text: result.data.message });
+      await loadEmails();
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : '削除に失敗しました';
+      setMessage({ type: 'error', text: errorMsg });
+    } finally {
+      setDeletingEmail(null);
+    }
+  };
+
+  const formatDate = (ts?: { _seconds: number; _nanoseconds: number }) => {
+    if (!ts) return '-';
+    return new Date(ts._seconds * 1000).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Modal */}
+      <div className="relative w-full max-w-2xl mx-4 bg-white rounded-2xl shadow-2xl max-h-[85vh] flex flex-col animate-in fade-in zoom-in-95 duration-200">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-stone-200">
+          <h2 className="text-lg font-bold text-stone-800 flex items-center gap-2">
+            <Users className="w-5 h-5 text-indigo-600" />
+            ユーザー管理
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-stone-100 rounded-full transition-colors"
+          >
+            <X className="w-5 h-5 text-stone-500" />
+          </button>
+        </div>
+
+        {/* Message */}
+        {message && (
+          <div
+            className={`mx-6 mt-4 p-3 rounded-lg text-sm flex items-center gap-2 animate-in slide-in-from-top-2 ${
+              message.type === 'success'
+                ? 'bg-green-50 text-green-700 border border-green-200'
+                : 'bg-red-50 text-red-700 border border-red-200'
+            }`}
+          >
+            {message.type === 'success' ? (
+              <Check className="w-4 h-4 flex-shrink-0" />
+            ) : (
+              <AlertCircle className="w-4 h-4 flex-shrink-0" />
+            )}
+            {message.text}
+          </div>
+        )}
+
+        {/* Add Form */}
+        <div className="px-6 py-4 border-b border-stone-100">
+          <h3 className="text-sm font-bold text-stone-500 uppercase mb-3">ユーザー追加</h3>
+          <div className="flex flex-col sm:flex-row gap-2">
+            <div className="flex-1 flex gap-2">
+              <div className="relative flex-1">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
+                <input
+                  type="email"
+                  placeholder="メールアドレス"
+                  value={newEmail}
+                  onChange={(e) => setNewEmail(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+                  className="w-full pl-9 pr-3 py-2 border border-stone-300 rounded-lg text-sm bg-white text-stone-900 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                />
+              </div>
+              <input
+                type="text"
+                placeholder="メモ（任意）"
+                value={newNote}
+                onChange={(e) => setNewNote(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+                className="w-32 sm:w-40 px-3 py-2 border border-stone-300 rounded-lg text-sm bg-white text-stone-900 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              />
+            </div>
+            <button
+              onClick={handleAdd}
+              disabled={isAdding || !newEmail.trim()}
+              className="flex items-center justify-center gap-1.5 px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isAdding ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Plus className="w-4 h-4" />
+              )}
+              追加
+            </button>
+          </div>
+        </div>
+
+        {/* Email List */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          <h3 className="text-sm font-bold text-stone-500 uppercase mb-3">
+            許可ユーザー一覧（{emails.length}件）
+          </h3>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="w-6 h-6 animate-spin text-stone-400" />
+            </div>
+          ) : emails.length === 0 ? (
+            <div className="text-center py-12 text-stone-400 text-sm">
+              許可されたユーザーはいません
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {emails.map((entry) => (
+                <div
+                  key={entry.email}
+                  className="flex items-center justify-between p-3 bg-stone-50 rounded-lg border border-stone-100 hover:bg-stone-100 transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-stone-800 truncate">{entry.email}</p>
+                    <div className="flex items-center gap-3 mt-0.5">
+                      {entry.addedBy && (
+                        <span className="text-xs text-stone-400">追加: {entry.addedBy}</span>
+                      )}
+                      <span className="text-xs text-stone-400">{formatDate(entry.createdAt)}</span>
+                      {entry.note && (
+                        <span className="text-xs text-stone-500 bg-stone-200 px-1.5 py-0.5 rounded">
+                          {entry.note}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleRemove(entry.email)}
+                    disabled={deletingEmail === entry.email}
+                    className="flex-shrink-0 p-2 text-stone-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                  >
+                    {deletingEmail === entry.email ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-3 border-t border-stone-200 text-xs text-stone-400 text-center">
+          許可リストに登録されたGoogleアカウントのみログインできます
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/admin/index.ts
+++ b/components/admin/index.ts
@@ -1,0 +1,1 @@
+export { WhitelistManagement } from './WhitelistManagement';

--- a/components/common/MenuDrawer.tsx
+++ b/components/common/MenuDrawer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Type, RefreshCw, Printer, LogOut, Settings, FileText, User, HelpCircle, Shield } from 'lucide-react';
+import { X, Type, RefreshCw, Printer, LogOut, Settings, FileText, User, Users, HelpCircle, Shield } from 'lucide-react';
 import { AppSettings } from '../../types';
 
 interface Props {
@@ -15,9 +15,11 @@ interface Props {
   onShowGuide: () => void;
   onShowHelp: () => void;
   onShowPrivacyPolicy: () => void;
+  isAdmin?: boolean;
+  onWhitelistManagement?: () => void;
 }
 
-export const MenuDrawer: React.FC<Props> = ({ isOpen, onClose, settings, onSettingsChange, onReset, onLogout, onPrint, onHospitalSheet, onCareManagerSettings, onShowGuide, onShowHelp, onShowPrivacyPolicy }) => {
+export const MenuDrawer: React.FC<Props> = ({ isOpen, onClose, settings, onSettingsChange, onReset, onLogout, onPrint, onHospitalSheet, onCareManagerSettings, onShowGuide, onShowHelp, onShowPrivacyPolicy, isAdmin, onWhitelistManagement }) => {
   if (!isOpen) return null;
 
   return (
@@ -138,6 +140,19 @@ export const MenuDrawer: React.FC<Props> = ({ isOpen, onClose, settings, onSetti
                 <Shield className="w-5 h-5 text-stone-500" />
                 <span className="font-medium">プライバシーポリシー</span>
              </button>
+             {isAdmin && onWhitelistManagement && (
+               <button
+                  onClick={() => {
+                    onWhitelistManagement();
+                    onClose();
+                  }}
+                  className="w-full flex items-center gap-3 p-3 hover:bg-indigo-50 rounded-lg text-stone-700 transition-colors border border-transparent hover:border-indigo-100"
+                >
+                  <Users className="w-5 h-5 text-indigo-600" />
+                  <span className="font-medium">ユーザー管理</span>
+                  <span className="ml-auto text-[10px] font-bold text-indigo-600 bg-indigo-100 px-1.5 py-0.5 rounded">Admin</span>
+               </button>
+             )}
              <button
                 onClick={() => {
                   onReset();

--- a/firestore.rules
+++ b/firestore.rules
@@ -6,15 +6,21 @@ service cloud.firestore {
       return request.auth != null;
     }
 
+    // 管理者チェック（Custom Claims: admin == true）
+    function isAdmin() {
+      return isAuthenticated() && request.auth.token.admin == true;
+    }
+
     // 自分のデータのみアクセス可
     function isOwner(userId) {
       return request.auth.uid == userId;
     }
 
-    // メール許可リスト（管理者のみ書き込み可、認証済みユーザーが自分のメールを読める）
+    // メール許可リスト（admin は全操作可、一般ユーザーは自分のメールのみ読取可）
     match /allowed_emails/{email} {
-      allow read: if isAuthenticated() && request.auth.token.email == email;
-      allow write: if false; // Cloud Consoleまたはスクリプト経由で管理
+      allow read: if isAdmin()
+                  || (isAuthenticated() && request.auth.token.email == email);
+      allow write: if isAdmin();
     }
 
     // フィードバック（認証済みユーザーが書き込みのみ）

--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -1,0 +1,107 @@
+import * as admin from 'firebase-admin';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions';
+
+const REGION = 'asia-northeast1';
+
+interface AuthInfo {
+  uid: string;
+  token: Record<string, unknown>;
+}
+
+// ------------------------------------------------------------------
+// ヘルパー: Admin権限チェック
+// ------------------------------------------------------------------
+function requireAdmin(auth: AuthInfo | undefined): asserts auth is AuthInfo {
+  if (!auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+  if (auth.token.admin !== true) {
+    throw new HttpsError('permission-denied', '管理者権限が必要です');
+  }
+}
+
+// ------------------------------------------------------------------
+// listAllowedEmails: 許可メール一覧取得（admin限定）
+// ------------------------------------------------------------------
+export const listAllowedEmails = onCall({ region: REGION }, async (request) => {
+  const auth = request.auth as AuthInfo | undefined;
+  requireAdmin(auth);
+
+  const db = admin.firestore();
+  const snapshot = await db.collection('allowed_emails').orderBy('createdAt', 'desc').get();
+
+  const emails = snapshot.docs.map((doc) => ({
+    email: doc.id,
+    ...doc.data(),
+  }));
+
+  logger.info(`listAllowedEmails: ${emails.length} entries returned`, { uid: auth.uid });
+
+  return { emails };
+});
+
+// ------------------------------------------------------------------
+// manageAllowedEmail: メール追加/削除（admin限定）
+// ------------------------------------------------------------------
+interface ManageAllowedEmailData {
+  action: 'add' | 'remove';
+  email: string;
+  note?: string;
+}
+
+export const manageAllowedEmail = onCall({ region: REGION }, async (request) => {
+  const auth = request.auth as AuthInfo | undefined;
+  requireAdmin(auth);
+
+  const { action, email, note } = request.data as ManageAllowedEmailData;
+
+  // バリデーション
+  if (!action || !['add', 'remove'].includes(action)) {
+    throw new HttpsError('invalid-argument', 'action は "add" または "remove" を指定してください');
+  }
+  if (!email || typeof email !== 'string') {
+    throw new HttpsError('invalid-argument', 'email は必須です');
+  }
+
+  // メール形式の簡易バリデーション
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    throw new HttpsError('invalid-argument', '有効なメールアドレスを入力してください');
+  }
+
+  const normalizedEmail = email.toLowerCase().trim();
+  const db = admin.firestore();
+  const emailRef = db.collection('allowed_emails').doc(normalizedEmail);
+
+  if (action === 'add') {
+    await emailRef.set({
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      addedBy: auth.token.email as string ?? auth.uid,
+      note: note ?? '',
+    });
+    logger.info(`manageAllowedEmail: added ${normalizedEmail}`, {
+      uid: auth.uid,
+      addedEmail: normalizedEmail,
+    });
+    return { success: true, message: `${normalizedEmail} を追加しました` };
+  }
+
+  // action === 'remove'
+  // 自分自身の削除防止
+  if (normalizedEmail === auth.token.email) {
+    throw new HttpsError('failed-precondition', '自分自身を削除することはできません');
+  }
+
+  const docSnap = await emailRef.get();
+  if (!docSnap.exists) {
+    throw new HttpsError('not-found', `${normalizedEmail} は許可リストに存在しません`);
+  }
+
+  await emailRef.delete();
+  logger.info(`manageAllowedEmail: removed ${normalizedEmail}`, {
+    uid: auth.uid,
+    removedEmail: normalizedEmail,
+  });
+  return { success: true, message: `${normalizedEmail} を削除しました` };
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,3 +12,6 @@ export {
 
 // デモデータリセット
 export { resetDemoData } from './resetDemo';
+
+// 管理者機能
+export { listAllowedEmails, manageAllowedEmail } from './admin';

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -92,6 +92,24 @@ async function seed() {
       throw new Error(`Auth Emulatorユーザー作成失敗: ${JSON.stringify(data)}`);
     }
     console.log(`  ✓ Auth Emulatorにテストユーザー作成 (uid: ${userId})`);
+
+    // テストユーザーに admin: true Custom Claims を設定
+    const claimRes = await fetch(
+      `http://localhost:9099/emulator/v1/projects/${PROJECT_ID}/accounts:update`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer owner' },
+        body: JSON.stringify({
+          localId: userId,
+          customAttributes: JSON.stringify({ admin: true }),
+        }),
+      }
+    );
+    if (!claimRes.ok) {
+      console.warn('  ⚠ admin Custom Claims設定失敗（テストは続行）');
+    } else {
+      console.log(`  ✓ admin Custom Claims設定完了 (uid: ${userId})`);
+    }
   }
 
   // ============================================================

--- a/scripts/set-admin.ts
+++ b/scripts/set-admin.ts
@@ -1,0 +1,91 @@
+/**
+ * 管理者Custom Claims設定スクリプト
+ *
+ * Usage:
+ *   npx tsx scripts/set-admin.ts <email>
+ *
+ * 前提: gcloud auth login 済み & gcloud config set project caremanager-ai-copilot-486212
+ *
+ * 処理:
+ *   1. Identity Toolkit API で email → UID 変換
+ *   2. UID に admin: true の Custom Claims を設定
+ */
+import { execSync } from 'child_process';
+
+const PROJECT_ID = 'caremanager-ai-copilot-486212';
+
+const email = process.argv[2];
+if (!email) {
+  console.error('Usage: npx tsx scripts/set-admin.ts <email>');
+  process.exit(1);
+}
+
+async function main() {
+  const accessToken = execSync('gcloud auth print-access-token', { encoding: 'utf-8' }).trim();
+
+  console.log(`\n🔐 管理者設定: ${email}`);
+  console.log(`   Project: ${PROJECT_ID}`);
+
+  // Step 1: email → UID
+  console.log('\n1. ユーザー情報を取得中...');
+  const lookupRes = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:lookup`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${accessToken}`,
+        'x-goog-user-project': PROJECT_ID,
+      },
+      body: JSON.stringify({ email: [email] }),
+    }
+  );
+
+  const lookupData = await lookupRes.json() as {
+    users?: Array<{ localId: string; email: string }>;
+    error?: { message: string };
+  };
+
+  if (!lookupRes.ok || !lookupData.users || lookupData.users.length === 0) {
+    console.error(`   ❌ ユーザーが見つかりません: ${email}`);
+    console.error(`   エラー: ${lookupData.error?.message ?? 'ユーザーが存在しません'}`);
+    process.exit(1);
+  }
+
+  const uid = lookupData.users[0].localId;
+  console.log(`   ✓ UID: ${uid}`);
+
+  // Step 2: Custom Claims 設定
+  console.log('\n2. Custom Claims (admin: true) を設定中...');
+  const updateRes = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:update`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${accessToken}`,
+        'x-goog-user-project': PROJECT_ID,
+      },
+      body: JSON.stringify({
+        localId: uid,
+        customAttributes: JSON.stringify({ admin: true }),
+      }),
+    }
+  );
+
+  const updateData = await updateRes.json() as { error?: { message: string } };
+
+  if (!updateRes.ok) {
+    console.error(`   ❌ Custom Claims設定失敗: ${updateData.error?.message ?? 'Unknown error'}`);
+    process.exit(1);
+  }
+
+  console.log(`   ✓ Custom Claims設定完了`);
+  console.log(`\n✅ ${email} を管理者に設定しました`);
+  console.log('   ※ ブラウザで再ログイン（またはトークンリフレッシュ）が必要です');
+}
+
+main().catch((err) => {
+  console.error('エラー:', err);
+  process.exit(1);
+});

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -77,6 +77,27 @@ export async function signInAsDemo(): Promise<User> {
 // デモデータリセット（Cloud Functions経由）
 export const resetDemoData = httpsCallable<void, { success: boolean }>(functions, 'resetDemoData');
 
+// ------------------------------------------------------------------
+// Admin: ホワイトリスト管理（Cloud Functions経由）
+// ------------------------------------------------------------------
+
+export interface AllowedEmailEntry {
+  email: string;
+  createdAt?: { _seconds: number; _nanoseconds: number };
+  addedBy?: string;
+  note?: string;
+}
+
+export const listAllowedEmailsFn = httpsCallable<void, { emails: AllowedEmailEntry[] }>(
+  functions,
+  'listAllowedEmails'
+);
+
+export const manageAllowedEmailFn = httpsCallable<
+  { action: 'add' | 'remove'; email: string; note?: string },
+  { success: boolean; message: string }
+>(functions, 'manageAllowedEmail');
+
 // Vertex AI呼び出し（Cloud Functions経由）
 interface AnalyzeAssessmentRequest {
   audioBase64?: string;


### PR DESCRIPTION
## Summary
- Firebase Custom Claims (`admin: true`) ベースのRBACを実装
- アプリ内からホワイトリスト（`allowed_emails`）の一覧・追加・削除が可能に
- 一般ユーザーには管理機能を非表示（admin限定メニュー）

## 変更内容
- **Backend**: `listAllowedEmails` / `manageAllowedEmail` Cloud Functions（admin限定、email バリデーション、自分自身削除防止）
- **Firestore Rules**: `isAdmin()` ヘルパー追加、`allowed_emails` を admin は全操作可 / 一般は自分のメールのみ読取可に更新
- **Frontend**: `AuthContext` に `isAdmin` state、`WhitelistManagement` モーダル、`MenuDrawer` にadmin限定メニュー
- **Scripts**: `set-admin.ts`（本番admin設定CLI）、`seed.ts`（Emulator admin claim自動設定）
- **Tests**: Firestore rules テスト7件追加（全51件パス）

## Test plan
- [x] Cloud Functions ビルド成功
- [x] Vite ビルド成功
- [x] Firestore rules テスト全51件パス
- [x] 本番確認OK（管理者メニュー表示・ホワイトリスト操作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)