### PR TITLE
fix(ux): エラー・案内メッセージを平易な日本語に改善

### DIFF
--- a/components/admin/WhitelistManagement.tsx
+++ b/components/admin/WhitelistManagement.tsx
@@ -23,7 +23,7 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
       const result = await listAllowedEmailsFn();
       setEmails(result.data.emails);
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : '一覧取得に失敗しました';
+      const errorMsg = err instanceof Error ? err.message : '一覧を読み込めませんでした。ページを再読み込みしてください。';
       setMessage({ type: 'error', text: errorMsg });
     } finally {
       setIsLoading(false);
@@ -66,7 +66,7 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
       setNewNote('');
       await loadEmails();
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : '追加に失敗しました';
+      const errorMsg = err instanceof Error ? err.message : '追加できませんでした。しばらくしてからもう一度お試しください。';
       setMessage({ type: 'error', text: errorMsg });
     } finally {
       setIsAdding(false);
@@ -83,7 +83,7 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
       setMessage({ type: 'success', text: result.data.message });
       await loadEmails();
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : '削除に失敗しました';
+      const errorMsg = err instanceof Error ? err.message : '削除できませんでした。しばらくしてからもう一度お試しください。';
       setMessage({ type: 'error', text: errorMsg });
     } finally {
       setDeletingEmail(null);

--- a/components/clients/ClientForm.tsx
+++ b/components/clients/ClientForm.tsx
@@ -148,7 +148,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
       onComplete();
     } catch (err) {
       console.error('Failed to save client:', err);
-      setError('保存に失敗しました');
+      setError('保存できませんでした。通信状況を確認してもう一度お試しください。');
     } finally {
       setSaving(false);
     }

--- a/components/meeting/ServiceMeetingForm.tsx
+++ b/components/meeting/ServiceMeetingForm.tsx
@@ -119,7 +119,7 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to load existing record:', error);
-      setLoadError('既存レコードの読み込みに失敗しました');
+      setLoadError('データの読み込みに失敗しました。ページを再読み込みしてください。');
     } finally {
       setLoading(false);
     }
@@ -207,7 +207,7 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to save service meeting record:', error);
-      alert('保存に失敗しました');
+      alert('保存できませんでした。通信状況を確認してもう一度お試しください。');
     } finally {
       setSaving(false);
     }

--- a/components/meeting/ServiceMeetingList.tsx
+++ b/components/meeting/ServiceMeetingList.tsx
@@ -47,7 +47,7 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
       setRecords(list);
     } catch (error) {
       console.error('Failed to load meeting records:', error);
-      setLoadError('会議記録の読み込みに失敗しました');
+      setLoadError('会議記録の読み込みに失敗しました。しばらくしてからもう一度お試しください。');
     } finally {
       setLoading(false);
     }
@@ -63,7 +63,7 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
       }
     } catch (error) {
       console.error('Failed to delete meeting record:', error);
-      alert('削除に失敗しました');
+      alert('削除できませんでした。しばらくしてからもう一度お試しください。');
     } finally {
       setDeletingId(null);
     }

--- a/components/monitoring/MonitoringDiffView.tsx
+++ b/components/monitoring/MonitoringDiffView.tsx
@@ -188,7 +188,7 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
         }
       } catch (error) {
         console.error('Failed to initialize form:', error);
-        setInitError('フォームの初期化に失敗しました');
+        setInitError('画面の準備に失敗しました。ページを再読み込みしてください。');
       } finally {
         setLoading(false);
       }
@@ -308,7 +308,7 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
       }
     } catch (error) {
       console.error('Failed to save monitoring record:', error);
-      alert('保存に失敗しました');
+      alert('保存できませんでした。通信状況を確認してもう一度お試しください。');
     } finally {
       setSaving(false);
     }

--- a/components/monitoring/MonitoringForm.tsx
+++ b/components/monitoring/MonitoringForm.tsx
@@ -107,7 +107,7 @@ export const MonitoringForm: React.FC<MonitoringFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to load existing record:', error);
-      setSaveError('既存レコードの読み込みに失敗しました');
+      setSaveError('データの読み込みに失敗しました。ページを再読み込みしてください。');
     } finally {
       setLoading(false);
     }
@@ -178,7 +178,7 @@ export const MonitoringForm: React.FC<MonitoringFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to save monitoring record:', error);
-      setSaveError('保存に失敗しました。再度お試しください。');
+      setSaveError('保存できませんでした。通信状況を確認してもう一度お試しください。');
     } finally {
       setSaving(false);
     }

--- a/components/monitoring/MonitoringRecordList.tsx
+++ b/components/monitoring/MonitoringRecordList.tsx
@@ -47,7 +47,7 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
       setRecords(list);
     } catch (error) {
       console.error('Failed to load monitoring records:', error);
-      setLoadError('モニタリング記録の読み込みに失敗しました');
+      setLoadError('モニタリング記録の読み込みに失敗しました。しばらくしてからもう一度お試しください。');
     } finally {
       setLoading(false);
     }
@@ -66,7 +66,7 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
       }
     } catch (error) {
       console.error('Failed to delete monitoring record:', error);
-      alert('削除に失敗しました');
+      alert('削除できませんでした。しばらくしてからもう一度お試しください。');
     } finally {
       setDeletingId(null);
     }

--- a/components/records/SupportRecordForm.tsx
+++ b/components/records/SupportRecordForm.tsx
@@ -83,7 +83,7 @@ export const SupportRecordForm: React.FC<SupportRecordFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to load existing record:', error);
-      setError('既存レコードの読み込みに失敗しました');
+      setError('データの読み込みに失敗しました。ページを再読み込みしてください。');
     } finally {
       setLoading(false);
     }
@@ -130,7 +130,7 @@ export const SupportRecordForm: React.FC<SupportRecordFormProps> = ({
       }
     } catch (err) {
       console.error('Failed to save support record:', err);
-      setError('保存に失敗しました。再度お試しください。');
+      setError('保存できませんでした。通信状況を確認してもう一度お試しください。');
     } finally {
       setSaving(false);
     }

--- a/components/records/SupportRecordList.tsx
+++ b/components/records/SupportRecordList.tsx
@@ -60,7 +60,7 @@ export const SupportRecordList: React.FC<SupportRecordListProps> = ({
       setRecords(data);
     } catch (err) {
       console.error('Failed to load support records:', err);
-      setError('記録の読み込みに失敗しました');
+      setError('記録の読み込みに失敗しました。しばらくしてからもう一度お試しください。');
     } finally {
       setLoading(false);
     }
@@ -74,7 +74,7 @@ export const SupportRecordList: React.FC<SupportRecordListProps> = ({
       setRecords((prev) => prev.filter((r) => r.id !== recordId));
     } catch (err) {
       console.error('Failed to delete record:', err);
-      alert('削除に失敗しました');
+      alert('削除できませんでした。しばらくしてからもう一度お試しください。');
     }
   };
 

--- a/components/settings/CareManagerSettingsModal.tsx
+++ b/components/settings/CareManagerSettingsModal.tsx
@@ -32,7 +32,7 @@ export const CareManagerSettingsModal: React.FC<Props> = ({ isOpen, onClose, ini
         onClose();
       }, 1000);
     } catch {
-      setMessage({ type: 'error', text: '保存に失敗しました' });
+      setMessage({ type: 'error', text: '保存できませんでした。しばらくしてからもう一度お試しください。' });
     } finally {
       setIsSaving(false);
     }


### PR DESCRIPTION
## Summary

- 全エラーメッセージに「次のどうすれば良いか」を追加（「〜できませんでした。〜してください。」形式に統一）
- 「レコード」「フォーム」「初期化」等のIT専門用語を平易な表現に置換
- 10ファイル、19箇所を変更

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| `削除に失敗しました` | `削除できませんでした。しばらくしてからもう一度お試しください。` |
| `保存に失敗しました` | `保存できませんでした。通信状況を確認してもう一度お試しください。` |
| `既存レコードの読み込みに失敗しました` | `データの読み込みに失敗しました。ページを再読み込みしてください。` |
| `フォームの初期化に失敗しました` | `画面の準備に失敗しました。ページを再読み込みしてください。` |
| `一覧取得に失敗しました` | `一覧を読み込めませんでした。ページを再読み込みしてください。` |

## Test plan

- [x] ビルド成功（`npm run build`）
- [x] テスト189件パス（`npm test`）
- [x] /safe-refactor チェック問題なし

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)