### PR TITLE
feat(ux): モバイル操作性改善（スマホ利用ケアマネ向け）

### DIFF
--- a/components/admin/WhitelistManagement.tsx
+++ b/components/admin/WhitelistManagement.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { X, Plus, Trash2, Loader2, Users, AlertCircle, Check, Mail } from 'lucide-react';
 import { listAllowedEmailsFn, manageAllowedEmailFn } from '../../services/firebase';
 import type { AllowedEmailEntry } from '../../services/firebase';
+import { ConfirmDialog } from '../common/ConfirmDialog';
 
 interface Props {
   isOpen: boolean;
@@ -16,6 +17,7 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
   const [isAdding, setIsAdding] = useState(false);
   const [deletingEmail, setDeletingEmail] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<string | null>(null);
 
   const loadEmails = useCallback(async () => {
     setIsLoading(true);
@@ -73,9 +75,12 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
     }
   };
 
-  const handleRemove = async (email: string) => {
-    if (!confirm(`${email} をアクセス許可リストから削除しますか？\nこのユーザーはログインできなくなります。`)) return;
+  const handleRemove = (email: string) => {
+    setRemoveTarget(email);
+  };
 
+  const executeRemove = async (email: string) => {
+    setRemoveTarget(null);
     setDeletingEmail(email);
     setMessage(null);
     try {
@@ -235,6 +240,16 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
           許可リストに登録されたGoogleアカウントのみログインできます
         </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={!!removeTarget}
+        title="ユーザーの削除"
+        message={`${removeTarget} をアクセス許可リストから削除しますか？\nこのユーザーはログインできなくなります。`}
+        variant="danger"
+        confirmLabel="削除"
+        onConfirm={() => removeTarget && executeRemove(removeTarget)}
+        onCancel={() => setRemoveTarget(null)}
+      />
     </div>
   );
 };

--- a/components/clients/ClientContextBar.tsx
+++ b/components/clients/ClientContextBar.tsx
@@ -52,7 +52,7 @@ export const ClientContextBar: React.FC<ClientContextBarProps> = ({
         </div>
         <button
           onClick={onEdit}
-          className="p-2 text-stone-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors flex-shrink-0"
+          className="p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center text-stone-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors flex-shrink-0"
           title="利用者情報を編集"
         >
           <Pencil className="w-4 h-4" />

--- a/components/clients/ClientForm.tsx
+++ b/components/clients/ClientForm.tsx
@@ -433,6 +433,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
               value={insurerNumber}
               onChange={(e) => { setInsurerNumber(e.target.value); setFieldErrors(prev => ({ ...prev, insurerNumber: '' })); }}
               placeholder="131001"
+              inputMode="numeric"
               maxLength={6}
               className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 text-sm text-stone-800 ${fieldErrors.insurerNumber ? 'border-red-400 focus:ring-red-400' : 'border-stone-300 focus:ring-blue-500'}`}
             />
@@ -445,6 +446,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
               value={insuredNumber}
               onChange={(e) => { setInsuredNumber(e.target.value); setFieldErrors(prev => ({ ...prev, insuredNumber: '' })); }}
               placeholder="0000000001"
+              inputMode="numeric"
               maxLength={10}
               className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 text-sm text-stone-800 ${fieldErrors.insuredNumber ? 'border-red-400 focus:ring-red-400' : 'border-stone-300 focus:ring-blue-500'}`}
             />

--- a/components/common/ConfirmDialog.tsx
+++ b/components/common/ConfirmDialog.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { AlertTriangle, Info } from 'lucide-react';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  showCancel?: boolean;
+  variant?: 'danger' | 'info';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  isOpen,
+  title,
+  message,
+  confirmLabel = 'OK',
+  cancelLabel = 'キャンセル',
+  showCancel = true,
+  variant = 'info',
+  onConfirm,
+  onCancel,
+}) => {
+  if (!isOpen) return null;
+
+  const isDanger = variant === 'danger';
+  const Icon = isDanger ? AlertTriangle : Info;
+
+  return (
+    <div
+      className="fixed inset-0 z-[400] flex items-center justify-center p-4 bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-sm bg-white rounded-xl shadow-2xl overflow-hidden">
+        <div className="p-5">
+          <div className="flex items-start gap-3">
+            <div
+              className={`flex-shrink-0 flex items-center justify-center w-10 h-10 rounded-full ${
+                isDanger ? 'bg-red-100' : 'bg-blue-100'
+              }`}
+            >
+              <Icon
+                className={`w-5 h-5 ${isDanger ? 'text-red-600' : 'text-blue-600'}`}
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-base font-bold text-stone-800">{title}</h3>
+              <p className="mt-1 text-sm text-stone-600 whitespace-pre-wrap">
+                {message}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="flex gap-3 px-5 pb-5">
+          {showCancel && (
+            <button
+              onClick={onCancel}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-stone-700 bg-stone-100 rounded-lg hover:bg-stone-200 transition-colors min-h-[44px]"
+            >
+              {cancelLabel}
+            </button>
+          )}
+          <button
+            onClick={onConfirm}
+            className={`flex-1 px-4 py-2.5 text-sm font-bold text-white rounded-lg transition-colors min-h-[44px] ${
+              isDanger
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-blue-600 hover:bg-blue-700'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/common/ErrorDialog.tsx
+++ b/components/common/ErrorDialog.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ConfirmDialog } from './ConfirmDialog';
+
+interface ErrorDialogProps {
+  message: string | null;
+  onClose: () => void;
+}
+
+export const ErrorDialog: React.FC<ErrorDialogProps> = ({ message, onClose }) => (
+  <ConfirmDialog
+    isOpen={!!message}
+    title="エラー"
+    message={message || ''}
+    showCancel={false}
+    onConfirm={onClose}
+    onCancel={onClose}
+  />
+);

--- a/components/common/MenuDrawer.tsx
+++ b/components/common/MenuDrawer.tsx
@@ -39,7 +39,7 @@ export const MenuDrawer: React.FC<Props> = ({ isOpen, onClose, settings, onSetti
           </h2>
           <button 
             onClick={onClose}
-            className="p-2 hover:bg-stone-200 rounded-full transition-colors"
+            className="p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-stone-200 rounded-full transition-colors"
           >
             <X className="w-6 h-6 text-stone-600" />
           </button>

--- a/components/meeting/ServiceMeetingForm.tsx
+++ b/components/meeting/ServiceMeetingForm.tsx
@@ -9,6 +9,7 @@ import {
   type ServiceMeetingRecordDocument,
 } from '../../services/firebase';
 import type { MeetingAttendee, MeetingAgendaItem, MeetingFormat } from '../../types';
+import { ErrorDialog } from '../common/ErrorDialog';
 
 interface ServiceMeetingFormProps {
   userId: string;
@@ -48,6 +49,7 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [errorDialog, setErrorDialog] = useState<string | null>(null);
 
   // 基本情報
   const [meetingDate, setMeetingDate] = useState(
@@ -207,7 +209,7 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
       }
     } catch (error) {
       console.error('Failed to save service meeting record:', error);
-      alert('保存できませんでした。通信状況を確認してもう一度お試しください。');
+      setErrorDialog('保存できませんでした。通信状況を確認してもう一度お試しください。');
     } finally {
       setSaving(false);
     }
@@ -498,6 +500,8 @@ export const ServiceMeetingForm: React.FC<ServiceMeetingFormProps> = ({
           {saving ? '保存中...' : '保存'}
         </button>
       </div>
+
+      <ErrorDialog message={errorDialog} onClose={() => setErrorDialog(null)} />
     </div>
   );
 };

--- a/components/meeting/ServiceMeetingList.tsx
+++ b/components/meeting/ServiceMeetingList.tsx
@@ -6,6 +6,8 @@ import {
   deleteServiceMeetingRecord,
   type ServiceMeetingRecordDocument,
 } from '../../services/firebase';
+import { ConfirmDialog } from '../common/ConfirmDialog';
+import { ErrorDialog } from '../common/ErrorDialog';
 
 interface ServiceMeetingListProps {
   userId: string;
@@ -32,6 +34,7 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [errorDialog, setErrorDialog] = useState<string | null>(null);
 
   useEffect(() => {
     loadRecords();
@@ -63,7 +66,7 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
       }
     } catch (error) {
       console.error('Failed to delete meeting record:', error);
-      alert('削除できませんでした。しばらくしてからもう一度お試しください。');
+      setErrorDialog('削除できませんでした。しばらくしてからもう一度お試しください。');
     } finally {
       setDeletingId(null);
     }
@@ -199,6 +202,8 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
           </div>
         );
       })}
+
+      <ErrorDialog message={errorDialog} onClose={() => setErrorDialog(null)} />
     </div>
   );
 };

--- a/components/monitoring/MonitoringDiffView.tsx
+++ b/components/monitoring/MonitoringDiffView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
+import { ErrorDialog } from '../common/ErrorDialog';
 import { Timestamp } from 'firebase/firestore';
 import { GoalEvaluationDiff } from './GoalEvaluationDiff';
 import { MonitoringCompareField } from './MonitoringCompareField';
@@ -112,6 +113,7 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
+  const [errorDialog, setErrorDialog] = useState<string | null>(null);
   const [diffMode, setDiffMode] = useState(true);
   const [previousRecord, setPreviousRecord] = useState<MonitoringRecordDocument | null>(null);
 
@@ -308,7 +310,7 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
       }
     } catch (error) {
       console.error('Failed to save monitoring record:', error);
-      alert('保存できませんでした。通信状況を確認してもう一度お試しください。');
+      setErrorDialog('保存できませんでした。通信状況を確認してもう一度お試しください。');
     } finally {
       setSaving(false);
     }
@@ -688,6 +690,8 @@ export const MonitoringDiffView: React.FC<MonitoringDiffViewProps> = ({
           {saving ? '保存中...' : '保存'}
         </button>
       </div>
+
+      <ErrorDialog message={errorDialog} onClose={() => setErrorDialog(null)} />
     </div>
   );
 };

--- a/components/monitoring/MonitoringRecordList.tsx
+++ b/components/monitoring/MonitoringRecordList.tsx
@@ -6,6 +6,8 @@ import {
   deleteMonitoringRecord,
   type MonitoringRecordDocument,
 } from '../../services/firebase';
+import { ConfirmDialog } from '../common/ConfirmDialog';
+import { ErrorDialog } from '../common/ErrorDialog';
 
 interface MonitoringRecordListProps {
   userId: string;
@@ -32,6 +34,8 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [errorDialog, setErrorDialog] = useState<string | null>(null);
 
   useEffect(() => {
     loadRecords();
@@ -53,10 +57,12 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
     }
   };
 
-  const handleDelete = async (recordId: string) => {
-    if (!confirm('この記録を削除してもよろしいですか？')) {
-      return;
-    }
+  const handleDelete = (recordId: string) => {
+    setDeleteTarget(recordId);
+  };
+
+  const executeDelete = async (recordId: string) => {
+    setDeleteTarget(null);
     setDeletingId(recordId);
     try {
       await deleteMonitoringRecord(userId, clientId, recordId);
@@ -66,7 +72,7 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
       }
     } catch (error) {
       console.error('Failed to delete monitoring record:', error);
-      alert('削除できませんでした。しばらくしてからもう一度お試しください。');
+      setErrorDialog('削除できませんでした。しばらくしてからもう一度お試しください。');
     } finally {
       setDeletingId(null);
     }
@@ -211,6 +217,17 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
           </div>
         );
       })}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="記録の削除"
+        message="この記録を削除してもよろしいですか？"
+        variant="danger"
+        confirmLabel="削除"
+        onConfirm={() => deleteTarget && executeDelete(deleteTarget)}
+        onCancel={() => setDeleteTarget(null)}
+      />
+      <ErrorDialog message={errorDialog} onClose={() => setErrorDialog(null)} />
     </div>
   );
 };

--- a/components/settings/CareManagerSettingsModal.tsx
+++ b/components/settings/CareManagerSettingsModal.tsx
@@ -46,7 +46,7 @@ export const CareManagerSettingsModal: React.FC<Props> = ({ isOpen, onClose, ini
             <User className="w-5 h-5 text-blue-600" />
             ケアマネ情報設定
           </h2>
-          <button onClick={onClose} className="p-2 hover:bg-stone-100 rounded-full transition-colors">
+          <button onClick={onClose} className="p-2.5 min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-stone-100 rounded-full transition-colors">
             <X className="w-5 h-5 text-stone-600" />
           </button>
         </div>
@@ -61,6 +61,7 @@ export const CareManagerSettingsModal: React.FC<Props> = ({ isOpen, onClose, ini
               type="text"
               className="w-full p-2 border border-stone-300 rounded-lg text-stone-900 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               placeholder="例：介護 太郎"
+              autoComplete="name"
               value={form.name}
               onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
             />
@@ -81,6 +82,7 @@ export const CareManagerSettingsModal: React.FC<Props> = ({ isOpen, onClose, ini
               type="tel"
               className="w-full p-2 border border-stone-300 rounded-lg text-stone-900 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               placeholder="例：03-0000-0000"
+              autoComplete="tel"
               value={form.phone}
               onChange={e => setForm(prev => ({ ...prev, phone: e.target.value }))}
             />


### PR DESCRIPTION
## Summary

- **タップターゲット 44px最小化**: `ClientContextBar`・`MenuDrawer`・`CareManagerSettingsModal` の小さいボタンに `min-w-[44px] min-h-[44px]` を追加
- **入力フォームのモバイル最適化**: `ClientForm`（保険者番号・被保険者番号）に `inputMode="numeric"`、`CareManagerSettingsModal` に `autoComplete="name"/"tel"` を追加
- **alert()/confirm() → アプリ内ダイアログ**: 全9箇所を `ConfirmDialog`/`ErrorDialog` コンポーネントに置換（ネイティブブラウザダイアログを完全排除）
- **`ErrorDialog` コンポーネント新設**: エラー通知パターンを `components/common/ErrorDialog.tsx` に共通化（DRY改善）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `components/common/ConfirmDialog.tsx` | 新規: 汎用確認ダイアログ（z-[400]、danger/infoバリアント、showCancelオプション） |
| `components/common/ErrorDialog.tsx` | 新規: エラー通知ダイアログラッパー |
| `App.tsx` | confirm() 2箇所 → ConfirmDialog、handleDemoReset/handleTabSwitch リファクタ |
| `components/admin/WhitelistManagement.tsx` | confirm() → ConfirmDialog |
| `components/clients/ClientContextBar.tsx` | タップターゲット 44px |
| `components/clients/ClientForm.tsx` | inputMode="numeric" |
| `components/common/MenuDrawer.tsx` | タップターゲット 44px |
| `components/meeting/ServiceMeetingForm.tsx` | alert() → ErrorDialog |
| `components/meeting/ServiceMeetingList.tsx` | alert() → ErrorDialog |
| `components/monitoring/MonitoringDiffView.tsx` | alert() → ErrorDialog |
| `components/monitoring/MonitoringRecordList.tsx` | alert() + confirm() → ConfirmDialog + ErrorDialog |
| `components/records/SupportRecordList.tsx` | alert() + confirm() → ConfirmDialog + ErrorDialog |
| `components/settings/CareManagerSettingsModal.tsx` | タップターゲット 44px + autoComplete追加 |

## Test plan

- [ ] ビルド成功確認: `npm run build` ✅
- [ ] テスト全通過: `npm test`（189件）✅
- [ ] スマートフォン実機 / DevToolsのモバイルエミュレーターでボタンタップ確認
- [ ] 削除ボタン押下時にアプリ内確認ダイアログが表示されること
- [ ] エラー発生時にブラウザネイティブalertではなくアプリ内ダイアログが表示されること

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)