### PR TITLE
feat(ux): 操作フロー簡略化（ITに疎いユーザー向け）

### DIFF
--- a/components/common/NextActionBanner.tsx
+++ b/components/common/NextActionBanner.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { ArrowRight, X } from 'lucide-react';
+
+interface NextActionBannerProps {
+  message: string;
+  actionLabel: string;
+  onAction: () => void;
+  onDismiss: () => void;
+  variant?: 'success' | 'info';
+}
+
+export const NextActionBanner: React.FC<NextActionBannerProps> = ({
+  message,
+  actionLabel,
+  onAction,
+  onDismiss,
+  variant = 'success',
+}) => {
+  const colors =
+    variant === 'success'
+      ? 'bg-emerald-50 border-emerald-200 text-emerald-800'
+      : 'bg-blue-50 border-blue-200 text-blue-800';
+
+  const btnColors =
+    variant === 'success'
+      ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
+      : 'bg-blue-600 hover:bg-blue-700 text-white';
+
+  return (
+    <div className={`flex items-center justify-between gap-3 rounded-lg border px-4 py-3 ${colors}`}>
+      <p className="text-sm font-medium flex-1">{message}</p>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          onClick={onAction}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors min-h-[44px] ${btnColors}`}
+        >
+          {actionLabel}
+          <ArrowRight className="w-4 h-4" />
+        </button>
+        <button
+          onClick={onDismiss}
+          className="p-1.5 rounded hover:bg-black/10 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center"
+          aria-label="閉じる"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/common/WorkflowStepper.tsx
+++ b/components/common/WorkflowStepper.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Check } from 'lucide-react';
+
+export type WorkflowStep = 'assessment' | 'plan' | 'monitoring' | 'records';
+
+interface Step {
+  id: WorkflowStep;
+  label: string;
+  shortLabel: string;
+}
+
+const STEPS: Step[] = [
+  { id: 'assessment', label: 'アセスメント', shortLabel: '課題分析' },
+  { id: 'plan', label: 'ケアプラン', shortLabel: 'プラン' },
+  { id: 'monitoring', label: 'モニタリング', shortLabel: '経過観察' },
+  { id: 'records', label: '支援経過', shortLabel: '記録' },
+];
+
+interface WorkflowStepperProps {
+  completedSteps: WorkflowStep[];
+  activeStep: WorkflowStep;
+  onStepClick: (step: WorkflowStep) => void;
+}
+
+export const WorkflowStepper: React.FC<WorkflowStepperProps> = ({
+  completedSteps,
+  activeStep,
+  onStepClick,
+}) => {
+  return (
+    <nav aria-label="ワークフロー進捗" className="flex items-center gap-0 overflow-x-auto">
+      {STEPS.map((step, index) => {
+        const isCompleted = completedSteps.includes(step.id);
+        const isActive = step.id === activeStep;
+
+        return (
+          <React.Fragment key={step.id}>
+            <button
+              onClick={() => onStepClick(step.id)}
+              className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-md transition-colors min-w-[60px] min-h-[44px] justify-center ${
+                isActive
+                  ? 'bg-blue-100 text-blue-700'
+                  : isCompleted
+                  ? 'text-emerald-700 hover:bg-emerald-50'
+                  : 'text-gray-400 hover:bg-gray-50'
+              }`}
+              aria-current={isActive ? 'step' : undefined}
+            >
+              <span
+                className={`w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold ${
+                  isActive
+                    ? 'bg-blue-600 text-white'
+                    : isCompleted
+                    ? 'bg-emerald-500 text-white'
+                    : 'bg-gray-200 text-gray-500'
+                }`}
+              >
+                {isCompleted && !isActive ? <Check className="w-3 h-3" /> : index + 1}
+              </span>
+              <span className="text-xs font-medium whitespace-nowrap hidden sm:block">
+                {step.label}
+              </span>
+              <span className="text-xs font-medium whitespace-nowrap sm:hidden">
+                {step.shortLabel}
+              </span>
+            </button>
+            {index < STEPS.length - 1 && (
+              <div
+                className={`w-4 h-0.5 shrink-0 ${
+                  isCompleted ? 'bg-emerald-400' : 'bg-gray-200'
+                }`}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </nav>
+  );
+};

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Users, LayoutDashboard } from 'lucide-react';
+import { Users, LayoutDashboard, UserPlus, ClipboardList, ArrowRight } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useClient } from '../../contexts/ClientContext';
 import { useDashboardData, filterActionItems } from '../../hooks/useDashboardData';
@@ -9,9 +9,10 @@ import { DashboardActionList } from './DashboardActionList';
 interface DashboardViewProps {
   onSelectClient: (clientId: string) => void;
   onViewAllClients: () => void;
+  onRegisterNewClient?: () => void;
 }
 
-export function DashboardView({ onSelectClient, onViewAllClients }: DashboardViewProps) {
+export function DashboardView({ onSelectClient, onViewAllClients, onRegisterNewClient }: DashboardViewProps) {
   const { user } = useAuth();
   const { clients, loadingClients } = useClient();
   const { items, isLoading, error, summary } = useDashboardData(user?.uid ?? null, clients);
@@ -51,6 +52,68 @@ export function DashboardView({ onSelectClient, onViewAllClients }: DashboardVie
 
       {/* サマリーカード */}
       <DashboardSummaryCards summary={summary} isLoading={loading} />
+
+      {/* クイックスタート（利用者0件時） */}
+      {!loading && clients.length === 0 && (
+        <div className="bg-blue-50 border border-blue-200 rounded-xl p-5">
+          <h3 className="text-sm font-bold text-blue-800 mb-3 flex items-center gap-2">
+            <ClipboardList className="w-4 h-4" />
+            まずここから始めましょう
+          </h3>
+          <ol className="space-y-2 mb-4 text-sm text-blue-700">
+            <li className="flex items-start gap-2">
+              <span className="w-5 h-5 rounded-full bg-blue-600 text-white text-xs flex items-center justify-center shrink-0 mt-0.5">1</span>
+              利用者を登録する
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="w-5 h-5 rounded-full bg-blue-200 text-blue-700 text-xs flex items-center justify-center shrink-0 mt-0.5">2</span>
+              アセスメント（課題分析）を入力する
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="w-5 h-5 rounded-full bg-blue-200 text-blue-700 text-xs flex items-center justify-center shrink-0 mt-0.5">3</span>
+              AIでケアプランを自動生成する
+            </li>
+          </ol>
+          {onRegisterNewClient && (
+            <button
+              onClick={onRegisterNewClient}
+              className="flex items-center gap-2 px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 min-h-[44px]"
+            >
+              <UserPlus className="w-4 h-4" />
+              最初の利用者を登録する
+              <ArrowRight className="w-4 h-4 ml-auto" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* クイックアクション（利用者がいる場合） */}
+      {!loading && clients.length > 0 && (
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            onClick={onViewAllClients}
+            className="flex flex-col items-start gap-1 p-3 bg-white border border-stone-200 rounded-xl hover:border-blue-300 hover:shadow-sm transition-all text-left min-h-[44px]"
+          >
+            <div className="flex items-center gap-1.5 text-blue-600">
+              <Users className="w-4 h-4" />
+              <span className="text-sm font-medium">利用者を選ぶ</span>
+            </div>
+            <p className="text-xs text-stone-400">アセスメント・プラン作成</p>
+          </button>
+          {onRegisterNewClient && (
+            <button
+              onClick={onRegisterNewClient}
+              className="flex flex-col items-start gap-1 p-3 bg-white border border-stone-200 rounded-xl hover:border-blue-300 hover:shadow-sm transition-all text-left min-h-[44px]"
+            >
+              <div className="flex items-center gap-1.5 text-emerald-600">
+                <UserPlus className="w-4 h-4" />
+                <span className="text-sm font-medium">利用者を登録</span>
+              </div>
+              <p className="text-xs text-stone-400">新規利用者の追加</p>
+            </button>
+          )}
+        </div>
+      )}
 
       {/* 要対応リスト */}
       <div className="bg-white rounded-xl border border-stone-200 p-4 shadow-sm">

--- a/components/meeting/ServiceMeetingList.tsx
+++ b/components/meeting/ServiceMeetingList.tsx
@@ -15,6 +15,7 @@ interface ServiceMeetingListProps {
   carePlanId?: string;
   onSelect?: (recordId: string) => void;
   onDelete?: (recordId: string) => void;
+  onAdd?: () => void;
 }
 
 const formatLabel: Record<string, string> = {
@@ -29,6 +30,7 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
   carePlanId,
   onSelect,
   onDelete,
+  onAdd,
 }) => {
   const [records, setRecords] = useState<ServiceMeetingRecordDocument[]>([]);
   const [loading, setLoading] = useState(true);
@@ -99,7 +101,16 @@ export const ServiceMeetingList: React.FC<ServiceMeetingListProps> = ({
     return (
       <div className="text-center py-8 text-gray-500">
         <Users className="w-12 h-12 mx-auto mb-3 text-gray-300" />
-        <p className="text-sm">会議記録がありません</p>
+        <p className="text-sm font-medium mb-1">会議記録がありません</p>
+        <p className="text-xs text-gray-400 mb-4">サービス担当者会議の内容を記録しましょう</p>
+        {onAdd && (
+          <button
+            onClick={onAdd}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 min-h-[44px]"
+          >
+            最初の会議記録を作成する
+          </button>
+        )}
       </div>
     );
   }

--- a/components/monitoring/MonitoringRecordList.tsx
+++ b/components/monitoring/MonitoringRecordList.tsx
@@ -15,6 +15,7 @@ interface MonitoringRecordListProps {
   carePlanId?: string;
   onSelect?: (recordId: string) => void;
   onDelete?: (recordId: string) => void;
+  onAdd?: () => void;
 }
 
 const visitMethodLabels: Record<string, string> = {
@@ -29,6 +30,7 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
   carePlanId,
   onSelect,
   onDelete,
+  onAdd,
 }) => {
   const [records, setRecords] = useState<MonitoringRecordDocument[]>([]);
   const [loading, setLoading] = useState(true);
@@ -114,7 +116,16 @@ export const MonitoringRecordList: React.FC<MonitoringRecordListProps> = ({
     return (
       <div className="text-center py-8 text-gray-500">
         <Activity className="w-12 h-12 mx-auto mb-3 text-gray-300" />
-        <p className="text-sm">モニタリング記録がありません</p>
+        <p className="text-sm font-medium mb-1">モニタリング記録がありません</p>
+        <p className="text-xs text-gray-400 mb-4">ケアプランの目標達成状況を記録しましょう</p>
+        {onAdd && (
+          <button
+            onClick={onAdd}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 min-h-[44px]"
+          >
+            最初のモニタリング記録を作成する
+          </button>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- **NextActionBanner**: アセスメント/ケアプラン保存後に次ステップを促すバナーを表示。1タップで次タブへ遷移
- **WorkflowStepper**: 4ステップの進捗インジケーター（アセスメント→ケアプラン→モニタリング→支援経過）をクライアント画面上部に常時表示
- **DashboardView**: 利用者0件時に「まずここから始めましょう」3ステップガイド＋CTAボタン。利用者ありの場合は「利用者を選ぶ」「利用者を登録」の2ボタングリッド
- **MonitoringRecordList / ServiceMeetingList**: 空状態に説明文＋「最初の記録を作成する」CTAボタンを追加

## Test plan

- [ ] ダッシュボード（利用者0件）→「最初の利用者を登録する」ボタン動作確認
- [ ] ダッシュボード（利用者あり）→「利用者を選ぶ」「利用者を登録」ボタン動作確認
- [ ] アセスメント保存 → NextActionBannerが表示され、「ケアプランを作成」タップでplanタブへ遷移
- [ ] ケアプラン保存 → NextActionBannerが表示され、「モニタリングへ」タップでmonitoringタブへ遷移
- [ ] WorkflowStepperで完了ステップ（緑チェック）・アクティブステップ（青）・未完了（グレー）が正しく表示
- [ ] WorkflowStepperのステップをタップしてタブ切替が動作
- [ ] モニタリング記録なし → 「最初のモニタリング記録を作成する」ボタン動作確認
- [ ] 会議記録なし → 「最初の会議記録を作成する」ボタン動作確認
- [ ] ビルド通過・テスト全通過（189件）

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)