### PR TITLE
refactor: 未使用import削除・エラーハンドリング改善・DRY修正

### DIFF
--- a/components/admin/WhitelistManagement.tsx
+++ b/components/admin/WhitelistManagement.tsx
@@ -4,6 +4,9 @@ import { listAllowedEmailsFn, manageAllowedEmailFn } from '../../services/fireba
 import type { AllowedEmailEntry } from '../../services/firebase';
 import { ConfirmDialog } from '../common/ConfirmDialog';
 
+const getErrorMessage = (err: unknown, fallback: string): string =>
+  err instanceof Error ? err.message : fallback;
+
 interface Props {
   isOpen: boolean;
   onClose: () => void;
@@ -25,8 +28,7 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
       const result = await listAllowedEmailsFn();
       setEmails(result.data.emails);
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : '一覧を読み込めませんでした。ページを再読み込みしてください。';
-      setMessage({ type: 'error', text: errorMsg });
+      setMessage({ type: 'error', text: getErrorMessage(err, '一覧を読み込めませんでした。ページを再読み込みしてください。') });
     } finally {
       setIsLoading(false);
     }
@@ -68,8 +70,7 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
       setNewNote('');
       await loadEmails();
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : '追加できませんでした。しばらくしてからもう一度お試しください。';
-      setMessage({ type: 'error', text: errorMsg });
+      setMessage({ type: 'error', text: getErrorMessage(err, '追加できませんでした。しばらくしてからもう一度お試しください。') });
     } finally {
       setIsAdding(false);
     }
@@ -88,8 +89,7 @@ export const WhitelistManagement: React.FC<Props> = ({ isOpen, onClose }) => {
       setMessage({ type: 'success', text: result.data.message });
       await loadEmails();
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : '削除できませんでした。しばらくしてからもう一度お試しください。';
-      setMessage({ type: 'error', text: errorMsg });
+      setMessage({ type: 'error', text: getErrorMessage(err, '削除できませんでした。しばらくしてからもう一度お試しください。') });
     } finally {
       setDeletingEmail(null);
     }

--- a/components/clients/ClientForm.tsx
+++ b/components/clients/ClientForm.tsx
@@ -26,6 +26,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const clearFieldError = (field: string) => setFieldErrors(prev => ({ ...prev, [field]: '' }));
 
   // フォームデータ
   const [name, setName] = useState(existingClient?.name || '');
@@ -431,7 +432,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
             <input
               type="text"
               value={insurerNumber}
-              onChange={(e) => { setInsurerNumber(e.target.value); setFieldErrors(prev => ({ ...prev, insurerNumber: '' })); }}
+              onChange={(e) => { setInsurerNumber(e.target.value); clearFieldError('insurerNumber'); }}
               placeholder="131001"
               inputMode="numeric"
               maxLength={6}
@@ -444,7 +445,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
             <input
               type="text"
               value={insuredNumber}
-              onChange={(e) => { setInsuredNumber(e.target.value); setFieldErrors(prev => ({ ...prev, insuredNumber: '' })); }}
+              onChange={(e) => { setInsuredNumber(e.target.value); clearFieldError('insuredNumber'); }}
               placeholder="0000000001"
               inputMode="numeric"
               maxLength={10}
@@ -457,7 +458,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
             <input
               type="date"
               value={certificationDate}
-              onChange={(e) => { setCertificationDate(e.target.value); setFieldErrors(prev => ({ ...prev, certificationExpiry: '' })); }}
+              onChange={(e) => { setCertificationDate(e.target.value); clearFieldError('certificationExpiry'); }}
               className="w-full px-3 py-2 border border-stone-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm text-stone-800"
             />
           </div>
@@ -466,7 +467,7 @@ export const ClientForm: React.FC<ClientFormProps> = ({
             <input
               type="date"
               value={certificationExpiry}
-              onChange={(e) => { setCertificationExpiry(e.target.value); setFieldErrors(prev => ({ ...prev, certificationExpiry: '' })); }}
+              onChange={(e) => { setCertificationExpiry(e.target.value); clearFieldError('certificationExpiry'); }}
               className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 text-sm text-stone-800 ${fieldErrors.certificationExpiry ? 'border-red-400 focus:ring-red-400' : 'border-stone-300 focus:ring-blue-500'}`}
             />
             {fieldErrors.certificationExpiry && <p className="mt-1 text-xs text-red-600">{fieldErrors.certificationExpiry}</p>}

--- a/components/meeting/ServiceMeetingList.tsx
+++ b/components/meeting/ServiceMeetingList.tsx
@@ -6,7 +6,6 @@ import {
   deleteServiceMeetingRecord,
   type ServiceMeetingRecordDocument,
 } from '../../services/firebase';
-import { ConfirmDialog } from '../common/ConfirmDialog';
 import { ErrorDialog } from '../common/ErrorDialog';
 
 interface ServiceMeetingListProps {

--- a/components/settings/CareManagerSettingsModal.tsx
+++ b/components/settings/CareManagerSettingsModal.tsx
@@ -31,7 +31,7 @@ export const CareManagerSettingsModal: React.FC<Props> = ({ isOpen, onClose, ini
         setMessage(null);
         onClose();
       }, 1000);
-    } catch {
+    } catch (_error) {
       setMessage({ type: 'error', text: '保存できませんでした。しばらくしてからもう一度お試しください。' });
     } finally {
       setIsSaving(false);


### PR DESCRIPTION
## Summary

- `ServiceMeetingList.tsx`: 未使用の `ConfirmDialog` importを削除
- `CareManagerSettingsModal.tsx`: `catch {}` を `catch (_error) {}` に修正（explicit binding）
- `WhitelistManagement.tsx`: `getErrorMessage` ヘルパー関数を追加し、3箇所のcatchブロックを統一
- `ClientForm.tsx`: `clearFieldError` ヘルパー関数を追加し、4箇所のインラインsetFieldErrorsパターンをDRY化

## Test plan

- [x] ビルド成功（1777 modules）
- [x] 全189テスト パス（1スキップ）
- [x] 挙動変更なし（リファクタリングのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)