### PR TITLE
feat(export): ケアプランCSVエクスポート機能 (#54 段階A)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,6 +28,7 @@ import { ClientListView, ClientForm, ClientContextBar } from './components/clien
 import { DashboardView } from './components/dashboard';
 import { WhitelistManagement } from './components/admin';
 import { ConfirmDialog } from './components/common/ConfirmDialog';
+import { exportTable2AsCsv, exportTable3AsCsv, downloadCsv, buildCsvFilename } from './utils/carePlanExport';
 import { generateHospitalAdmissionSheet, UserBasicInfo, CareManagerInfo } from './utils/hospitalAdmissionSheet';
 
 // Updated Initial Assessment matching 23 Items Structure
@@ -394,6 +395,13 @@ export default function App() {
     );
   }
 
+  const handleCsvExport = () => {
+    if (!selectedClient) return;
+    const clientName = selectedClient.name;
+    downloadCsv(exportTable2AsCsv(plan, clientName), buildCsvFilename(clientName, '第2表'));
+    downloadCsv(exportTable3AsCsv(plan, clientName), buildCsvFilename(clientName, '第3表'));
+  };
+
   const handleDateChange = (field: keyof CarePlan, value: string) => {
     handleUpdatePlan({ [field]: value } as Partial<CarePlan>);
   };
@@ -577,6 +585,7 @@ export default function App() {
         onReset={handleReset}
         onLogout={logout}
         onPrint={() => selectedClient && setShowPrintPreview(true)}
+        onCsvExport={selectedClient ? handleCsvExport : undefined}
         onHospitalSheet={() => selectedClient && handleGenerateHospitalSheet()}
         onCareManagerSettings={() => setShowCareManagerSettings(true)}
         onShowGuide={reopenTour}

--- a/components/common/MenuDrawer.tsx
+++ b/components/common/MenuDrawer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Type, RefreshCw, Printer, LogOut, Settings, FileText, User, Users, HelpCircle, Shield } from 'lucide-react';
+import { X, Type, RefreshCw, Printer, LogOut, Settings, FileText, User, Users, HelpCircle, Shield, Download } from 'lucide-react';
 import { AppSettings } from '../../types';
 
 interface Props {
@@ -10,6 +10,7 @@ interface Props {
   onReset: () => void;
   onLogout: () => void;
   onPrint: () => void;
+  onCsvExport?: () => void;
   onHospitalSheet: () => void;
   onCareManagerSettings: () => void;
   onShowGuide: () => void;
@@ -19,7 +20,7 @@ interface Props {
   onWhitelistManagement?: () => void;
 }
 
-export const MenuDrawer: React.FC<Props> = ({ isOpen, onClose, settings, onSettingsChange, onReset, onLogout, onPrint, onHospitalSheet, onCareManagerSettings, onShowGuide, onShowHelp, onShowPrivacyPolicy, isAdmin, onWhitelistManagement }) => {
+export const MenuDrawer: React.FC<Props> = ({ isOpen, onClose, settings, onSettingsChange, onReset, onLogout, onPrint, onCsvExport, onHospitalSheet, onCareManagerSettings, onShowGuide, onShowHelp, onShowPrivacyPolicy, isAdmin, onWhitelistManagement }) => {
   if (!isOpen) return null;
 
   return (
@@ -120,6 +121,18 @@ export const MenuDrawer: React.FC<Props> = ({ isOpen, onClose, settings, onSetti
                 <Printer className="w-5 h-5 text-blue-500" />
                 <span className="font-medium">第1表・第2表 印刷プレビュー</span>
              </button>
+             {onCsvExport && (
+               <button
+                 onClick={() => {
+                   onCsvExport();
+                   onClose();
+                 }}
+                 className="w-full flex items-center gap-3 p-3 hover:bg-teal-50 rounded-lg text-stone-700 transition-colors border border-transparent hover:border-teal-100"
+               >
+                 <Download className="w-5 h-5 text-teal-600" />
+                 <span className="font-medium">ケアプランCSVエクスポート</span>
+               </button>
+             )}
              <button
                 onClick={() => {
                   onHospitalSheet();

--- a/tests/utils/carePlanExport.test.ts
+++ b/tests/utils/carePlanExport.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from 'vitest';
+import {
+  exportTable2AsCsv,
+  exportTable3AsCsv,
+  buildCsvFilename,
+  DAY_LABELS,
+  GOAL_STATUS_LABELS,
+} from '../../utils/carePlanExport';
+import type { CarePlan } from '../../types';
+
+// テスト用の最小限ケアプランデータ
+const basePlan: CarePlan = {
+  id: 'plan-1',
+  userId: 'user-1',
+  status: 'active',
+  assessmentDate: '2026-01-01',
+  draftDate: '2026-01-10',
+  meetingDate: '2026-01-15',
+  consentDate: '2026-01-20',
+  deliveryDate: '2026-01-20',
+  longTermGoal: '',
+  shortTermGoals: [],
+};
+
+// --- 第2表 CSV テスト ---
+
+describe('exportTable2AsCsv', () => {
+  describe('V2ニーズ構造（正常系）', () => {
+    it('1ニーズ・1サービスで2行（ヘッダー+データ）を出力する', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        needs: [
+          {
+            id: 'n1',
+            content: '食事の自立支援',
+            longTermGoal: '自分で食事ができる',
+            longTermGoalStartDate: '2026-01-01',
+            longTermGoalEndDate: '2026-06-30',
+            shortTermGoals: [
+              {
+                id: 'g1',
+                content: '箸を使って食べる',
+                status: 'in_progress',
+                startDate: '2026-01-01',
+                endDate: '2026-03-31',
+              },
+            ],
+            services: [
+              {
+                id: 's1',
+                content: '食事の声かけ・見守り',
+                type: '訪問介護',
+                frequency: '週3回',
+              },
+            ],
+          },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, '山田太郎');
+      const lines = csv.split('\r\n');
+
+      expect(lines).toHaveLength(2); // ヘッダー + 1データ行
+      expect(lines[0]).toContain('利用者名');
+      expect(lines[0]).toContain('ニーズ（生活全般の課題）');
+      expect(lines[0]).toContain('サービス種別');
+      expect(lines[1]).toContain('山田太郎');
+      expect(lines[1]).toContain('食事の自立支援');
+      expect(lines[1]).toContain('訪問介護');
+      expect(lines[1]).toContain('食事の声かけ・見守り');
+      expect(lines[1]).toContain('週3回');
+    });
+
+    it('複数サービスがある場合、サービスごとに行が展開される', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        needs: [
+          {
+            id: 'n1',
+            content: 'ニーズ1',
+            longTermGoal: '長期目標1',
+            shortTermGoals: [],
+            services: [
+              { id: 's1', content: 'サービスA', type: '訪問介護', frequency: '週2回' },
+              { id: 's2', content: 'サービスB', type: '通所介護', frequency: '週1回' },
+            ],
+          },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, '鈴木花子');
+      const lines = csv.split('\r\n');
+
+      expect(lines).toHaveLength(3); // ヘッダー + 2サービス行
+      expect(lines[1]).toContain('サービスA');
+      expect(lines[2]).toContain('サービスB');
+    });
+
+    it('複数の短期目標は「・」で結合される', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        needs: [
+          {
+            id: 'n1',
+            content: 'ニーズ',
+            longTermGoal: '長期目標',
+            shortTermGoals: [
+              { id: 'g1', content: '短期目標A', status: 'in_progress' },
+              { id: 'g2', content: '短期目標B', status: 'not_started' },
+            ],
+            services: [{ id: 's1', content: 'サービス', type: '訪問介護', frequency: '週1回' }],
+          },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, 'テスト太郎');
+      expect(csv).toContain('短期目標A');
+      expect(csv).toContain('短期目標B');
+      expect(csv).toContain('・');
+    });
+
+    it('サービスなしのニーズは1行のみ出力される', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        needs: [
+          {
+            id: 'n1',
+            content: 'ニーズのみ',
+            longTermGoal: '長期目標',
+            shortTermGoals: [],
+            services: [],
+          },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, 'テスト');
+      const lines = csv.split('\r\n');
+      expect(lines).toHaveLength(2); // ヘッダー + 1行
+      expect(lines[1]).toContain('ニーズのみ');
+    });
+
+    it('複数ニーズがある場合、各ニーズのサービスが展開される', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        needs: [
+          {
+            id: 'n1',
+            content: 'ニーズ1',
+            longTermGoal: '長期目標1',
+            shortTermGoals: [],
+            services: [{ id: 's1', content: 'サービス1', type: '訪問介護', frequency: '週3回' }],
+          },
+          {
+            id: 'n2',
+            content: 'ニーズ2',
+            longTermGoal: '長期目標2',
+            shortTermGoals: [],
+            services: [
+              { id: 's2', content: 'サービス2', type: '通所介護', frequency: '週2回' },
+              { id: 's3', content: 'サービス3', type: '訪問看護', frequency: '月2回' },
+            ],
+          },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, 'テスト');
+      const lines = csv.split('\r\n');
+      expect(lines).toHaveLength(4); // ヘッダー + 3サービス行
+    });
+  });
+
+  describe('V1フォールバック（needsなし）', () => {
+    it('shortTermGoalsを行として出力する', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        longTermGoal: 'V1長期目標',
+        longTermGoalStartDate: '2026-01-01',
+        longTermGoalEndDate: '2026-12-31',
+        shortTermGoals: [
+          { id: 'g1', content: 'V1短期目標A', status: 'in_progress' },
+          { id: 'g2', content: 'V1短期目標B', status: 'achieved' },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, 'テスト');
+      const lines = csv.split('\r\n');
+      expect(lines).toHaveLength(3); // ヘッダー + 2目標行
+      expect(lines[1]).toContain('V1長期目標');
+      expect(lines[1]).toContain('V1短期目標A');
+      expect(lines[1]).toContain('実施中');
+      expect(lines[2]).toContain('V1短期目標B');
+      expect(lines[2]).toContain('達成');
+    });
+
+    it('shortTermGoalsもない場合、1行のみ出力する', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        longTermGoal: '目標のみ',
+        shortTermGoals: [],
+      };
+
+      const csv = exportTable2AsCsv(plan, 'テスト');
+      const lines = csv.split('\r\n');
+      expect(lines).toHaveLength(2); // ヘッダー + 1行
+    });
+  });
+
+  describe('CSVエスケープ', () => {
+    it('カンマを含む値はダブルクォートで囲まれる', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        needs: [
+          {
+            id: 'n1',
+            content: '食事,入浴の支援',  // 半角カンマを含む
+            longTermGoal: '目標A,目標B',  // 半角カンマを含む
+            shortTermGoals: [],
+            services: [{ id: 's1', content: 'サービス', type: '訪問介護', frequency: '週1回' }],
+          },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, 'テスト');
+      expect(csv).toContain('"食事,入浴の支援"');
+      expect(csv).toContain('"目標A,目標B"');
+    });
+
+    it('ダブルクォートを含む値はエスケープされる', () => {
+      const plan: CarePlan = {
+        ...basePlan,
+        needs: [
+          {
+            id: 'n1',
+            content: '「自分で」できる',
+            longTermGoal: '目標',
+            shortTermGoals: [],
+            services: [{ id: 's1', content: '"特殊"サービス', type: '訪問介護', frequency: '週1回' }],
+          },
+        ],
+      };
+
+      const csv = exportTable2AsCsv(plan, 'テスト');
+      expect(csv).toContain('""特殊""');
+    });
+  });
+});
+
+// --- 第3表 CSV テスト ---
+
+describe('exportTable3AsCsv', () => {
+  it('週間スケジュールエントリを1行で出力する', () => {
+    const plan: CarePlan = {
+      ...basePlan,
+      weeklySchedule: {
+        entries: [
+          {
+            id: 'e1',
+            serviceType: '訪問介護',
+            provider: 'テストヘルパーステーション',
+            content: '生活援助',
+            days: ['mon', 'wed', 'fri'],
+            startTime: '09:00',
+            endTime: '10:00',
+            frequency: '週3回',
+            notes: '備考テキスト',
+          },
+        ],
+        mainActivities: '散歩・体操',
+        weeklyNote: '月1回通院',
+      },
+    };
+
+    const csv = exportTable3AsCsv(plan, '山田太郎');
+    const lines = csv.split('\r\n');
+
+    expect(lines).toHaveLength(2); // ヘッダー + 1エントリ
+    expect(lines[0]).toContain('月');
+    expect(lines[0]).toContain('開始時間');
+    expect(lines[1]).toContain('山田太郎');
+    expect(lines[1]).toContain('訪問介護');
+    expect(lines[1]).toContain('テストヘルパーステーション');
+    expect(lines[1]).toContain('09:00');
+    expect(lines[1]).toContain('10:00');
+    expect(lines[1]).toContain('備考テキスト');
+  });
+
+  it('実施曜日に○、未実施日は空白を出力する', () => {
+    const plan: CarePlan = {
+      ...basePlan,
+      weeklySchedule: {
+        entries: [
+          {
+            id: 'e1',
+            serviceType: '訪問介護',
+            provider: '事業所',
+            content: 'サービス',
+            days: ['mon', 'fri'], // 月・金のみ
+            startTime: '10:00',
+            endTime: '11:00',
+            frequency: '週2回',
+            notes: '',
+          },
+        ],
+        mainActivities: '',
+        weeklyNote: '',
+      },
+    };
+
+    const csv = exportTable3AsCsv(plan, 'テスト');
+    const lines = csv.split('\r\n');
+    // 月(○),火( ),水( ),木( ),金(○),土( ),日( )
+    const dataLine = lines[1];
+    const cells = dataLine.split(',');
+    // 月は index 4 (0:利用者名,1:種別,2:事業所,3:内容,4:月,5:火,...)
+    expect(cells[4]).toBe('○'); // 月
+    expect(cells[5]).toBe('');  // 火
+    expect(cells[6]).toBe('');  // 水
+    expect(cells[7]).toBe('');  // 木
+    expect(cells[8]).toBe('○'); // 金
+    expect(cells[9]).toBe('');  // 土
+    expect(cells[10]).toBe(''); // 日
+  });
+
+  it('weeklyScheduleがnullの場合、ヘッダーのみ出力する', () => {
+    const csv = exportTable3AsCsv(basePlan, 'テスト');
+    const lines = csv.split('\r\n');
+    expect(lines).toHaveLength(1); // ヘッダーのみ
+  });
+
+  it('エントリが空の場合、ヘッダーのみ出力する', () => {
+    const plan: CarePlan = {
+      ...basePlan,
+      weeklySchedule: { entries: [], mainActivities: '', weeklyNote: '' },
+    };
+    const csv = exportTable3AsCsv(plan, 'テスト');
+    const lines = csv.split('\r\n');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('複数エントリはそれぞれ1行で出力される', () => {
+    const plan: CarePlan = {
+      ...basePlan,
+      weeklySchedule: {
+        entries: [
+          { id: 'e1', serviceType: '訪問介護', provider: '事業所A', content: 'サービスA', days: ['mon'], startTime: '09:00', endTime: '10:00', frequency: '週1回', notes: '' },
+          { id: 'e2', serviceType: '通所介護', provider: '事業所B', content: 'サービスB', days: ['wed', 'fri'], startTime: '10:00', endTime: '16:00', frequency: '週2回', notes: '' },
+        ],
+        mainActivities: '',
+        weeklyNote: '',
+      },
+    };
+
+    const csv = exportTable3AsCsv(plan, 'テスト');
+    const lines = csv.split('\r\n');
+    expect(lines).toHaveLength(3); // ヘッダー + 2エントリ
+  });
+});
+
+// --- ファイル名生成テスト ---
+
+describe('buildCsvFilename', () => {
+  it('利用者名・表番号・日付を含むファイル名を生成する', () => {
+    const filename = buildCsvFilename('山田太郎', '第2表');
+    expect(filename).toMatch(/^山田太郎_第2表_\d{8}\.csv$/);
+  });
+
+  it('ファイル名に使用できない文字は_に置換される', () => {
+    const filename = buildCsvFilename('山田/太郎', '第2表');
+    expect(filename).toContain('山田_太郎');
+    expect(filename).not.toContain('/');
+  });
+});
+
+// --- 定数テスト ---
+
+describe('定数', () => {
+  it('DAY_LABELSに全曜日が定義されている', () => {
+    const days = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    for (const day of days) {
+      expect(DAY_LABELS[day]).toBeDefined();
+    }
+  });
+
+  it('GOAL_STATUS_LABELSに全ステータスが定義されている', () => {
+    const statuses = ['not_started', 'in_progress', 'achieved', 'discontinued'];
+    for (const status of statuses) {
+      expect(GOAL_STATUS_LABELS[status]).toBeDefined();
+    }
+  });
+});

--- a/utils/carePlanExport.ts
+++ b/utils/carePlanExport.ts
@@ -1,0 +1,217 @@
+/**
+ * ケアプランCSVエクスポートユーティリティ
+ *
+ * 第2表（居宅サービス計画書）・第3表（週間サービス計画表）を
+ * CSV形式でエクスポートし、他の介護ソフトへの転記を支援します。
+ *
+ * フォーマット: UTF-8 BOM付き、CRLF改行（Excel互換）
+ */
+import type { CarePlan } from '../types';
+
+// 曜日の日本語ラベル
+const DAY_LABELS: Record<string, string> = {
+  mon: '月',
+  tue: '火',
+  wed: '水',
+  thu: '木',
+  fri: '金',
+  sat: '土',
+  sun: '日',
+};
+
+const GOAL_STATUS_LABELS: Record<string, string> = {
+  not_started: '未開始',
+  in_progress: '実施中',
+  achieved: '達成',
+  discontinued: '中止',
+};
+
+/** 1セルのCSVエスケープ処理 */
+function escapeCell(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** 行配列からCSV文字列を生成（CRLF改行） */
+function buildCsv(rows: string[][]): string {
+  return rows.map((row) => row.map(escapeCell).join(',')).join('\r\n');
+}
+
+/**
+ * 第2表（居宅サービス計画書）をCSV形式に変換します。
+ *
+ * フォーマット: 1サービスを1行として展開し、ニーズ・目標を各行に付与。
+ * 複数の短期目標がある場合は「・」で結合して1列に収めます。
+ * V1データ（needsなし）の場合は shortTermGoals を行として出力します。
+ *
+ * @param plan ケアプランデータ
+ * @param clientName 利用者氏名（1列目に出力）
+ */
+export function exportTable2AsCsv(plan: CarePlan, clientName: string): string {
+  const rows: string[][] = [];
+
+  rows.push([
+    '利用者名',
+    'ニーズ（生活全般の課題）',
+    '長期目標',
+    '長期目標開始日',
+    '長期目標終了日',
+    '短期目標',
+    'サービス種別',
+    'サービス内容',
+    '頻度',
+  ]);
+
+  const needs = plan.needs ?? [];
+
+  if (needs.length === 0) {
+    // V1フォールバック: ニーズ構造なし → longTermGoal + shortTermGoals を使用
+    for (const goal of plan.shortTermGoals) {
+      rows.push([
+        clientName,
+        '',
+        plan.longTermGoal,
+        plan.longTermGoalStartDate ?? '',
+        plan.longTermGoalEndDate ?? '',
+        `${goal.content}（${GOAL_STATUS_LABELS[goal.status] ?? goal.status}）`,
+        '',
+        '',
+        '',
+      ]);
+    }
+    if (plan.shortTermGoals.length === 0) {
+      rows.push([clientName, '', plan.longTermGoal, '', '', '', '', '', '']);
+    }
+    return buildCsv(rows);
+  }
+
+  for (const need of needs) {
+    const shortTermGoalSummary = need.shortTermGoals
+      .map((g) => `${g.content}（${GOAL_STATUS_LABELS[g.status] ?? g.status}）`)
+      .join('・');
+
+    if (need.services.length === 0) {
+      // サービスなし → ニーズ行のみ出力
+      rows.push([
+        clientName,
+        need.content,
+        need.longTermGoal,
+        need.longTermGoalStartDate ?? '',
+        need.longTermGoalEndDate ?? '',
+        shortTermGoalSummary,
+        '',
+        '',
+        '',
+      ]);
+      continue;
+    }
+
+    for (const service of need.services) {
+      rows.push([
+        clientName,
+        need.content,
+        need.longTermGoal,
+        need.longTermGoalStartDate ?? '',
+        need.longTermGoalEndDate ?? '',
+        shortTermGoalSummary,
+        service.type,
+        service.content,
+        service.frequency,
+      ]);
+    }
+  }
+
+  return buildCsv(rows);
+}
+
+/**
+ * 第3表（週間サービス計画表）をCSV形式に変換します。
+ *
+ * フォーマット: 1エントリを1行として展開。曜日は○/空白で表示。
+ *
+ * @param plan ケアプランデータ
+ * @param clientName 利用者氏名（1列目に出力）
+ */
+export function exportTable3AsCsv(plan: CarePlan, clientName: string): string {
+  const rows: string[][] = [];
+
+  rows.push([
+    '利用者名',
+    'サービス種別',
+    '事業所名',
+    'サービス内容',
+    '月',
+    '火',
+    '水',
+    '木',
+    '金',
+    '土',
+    '日',
+    '開始時間',
+    '終了時間',
+    '頻度',
+    '備考',
+  ]);
+
+  const schedule = plan.weeklySchedule;
+  if (!schedule || schedule.entries.length === 0) {
+    return buildCsv(rows);
+  }
+
+  for (const entry of schedule.entries) {
+    const days = (['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const).map((d) =>
+      entry.days.includes(d) ? '○' : ''
+    );
+
+    rows.push([
+      clientName,
+      entry.serviceType,
+      entry.provider,
+      entry.content,
+      ...days,
+      entry.startTime,
+      entry.endTime,
+      entry.frequency,
+      entry.notes,
+    ]);
+  }
+
+  return buildCsv(rows);
+}
+
+/**
+ * CSVコンテンツをファイルとしてダウンロードします（UTF-8 BOM付き）。
+ *
+ * @param content CSV文字列
+ * @param filename ダウンロードファイル名
+ */
+export function downloadCsv(content: string, filename: string): void {
+  const bom = '\uFEFF'; // UTF-8 BOM（Excel互換）
+  const blob = new Blob([bom + content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * 利用者名・日付からCSVファイル名を生成します。
+ * 例: "山田太郎_第2表_20260223.csv"
+ *
+ * @param clientName 利用者氏名
+ * @param tableNumber 表番号（"第2表" など）
+ */
+export function buildCsvFilename(clientName: string, tableNumber: string): string {
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const safeName = clientName.replace(/[/\\:*?"<>|]/g, '_');
+  return `${safeName}_${tableNumber}_${today}.csv`;
+}
+
+/** 曜日ラベルの公開（テスト用） */
+export { DAY_LABELS, GOAL_STATUS_LABELS };


### PR DESCRIPTION
## Summary

- ケアプラン第2表（居宅サービス計画書）・第3表（週間サービス計画表）をCSVエクスポートできるようにしました
- メニュードロワーに「ケアプランCSVエクスポート」ボタンを追加
- 第2表・第3表を同時にダウンロード（利用者名+日付付きファイル名）
- UTF-8 BOM付き・CRLF改行（Excel互換）

## 技術詳細

- `utils/carePlanExport.ts`: 変換ロジック（V2ニーズ構造・V1フォールバック両対応）
- 第2表: 1サービスを1行に展開。複数の短期目標は「・」で結合
- 第3表: 曜日を○/空白で表現
- CSVエスケープ: カンマ・ダブルクォート・改行を正しく処理

## Test plan

- [x] ユニットテスト 18ケース追加・全パス
- [x] ビルド成功（1777 modules）
- [x] 全207テスト パス（1スキップ）
- [ ] Excel で開いて文字化けなし・曜日○表示を手動確認

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)