### PR TITLE
fix(e2e): strict mode violation - タブセレクターをdata-testidでスコープ (#68)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -829,7 +829,7 @@ export default function App() {
             )}
 
             {/* Navigation Tabs (Mobile optimized) */}
-            <div className="flex bg-white rounded-xl shadow-sm p-1 border border-stone-200 overflow-x-auto no-scrollbar">
+            <div data-testid="tab-navigation" className="flex bg-white rounded-xl shadow-sm p-1 border border-stone-200 overflow-x-auto no-scrollbar">
               {[
                 { id: 'assessment', icon: FileText, label: 'アセスメント' },
                 { id: 'plan', icon: ShieldCheck, label: 'ケアプラン' },

--- a/e2e/02-client-registration.spec.ts
+++ b/e2e/02-client-registration.spec.ts
@@ -39,6 +39,6 @@ test.describe('利用者登録・編集', () => {
     // ClientContextBarに利用者名が表示される
     await expect(page.getByText('田中 花子')).toBeVisible();
     // タブナビゲーションが表示される
-    await expect(page.getByRole('button', { name: 'アセスメント' })).toBeVisible();
+    await expect(page.locator('[data-testid="tab-navigation"]').getByRole('button', { name: 'アセスメント' })).toBeVisible();
   });
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -38,7 +38,6 @@ export async function selectClient(page: Page, clientName: string) {
  * デスクトップビューポートではテキストで選択可能
  */
 export async function switchTab(page: Page, tabLabel: string) {
-  // テキストラベルが見えるならクリック
-  const tab = page.getByText(tabLabel, { exact: true });
-  await tab.click();
+  const nav = page.locator('[data-testid="tab-navigation"]');
+  await nav.getByText(tabLabel, { exact: true }).click();
 }


### PR DESCRIPTION
## Summary

- WorkflowStepperとタブナビゲーションに同一ラベルテキスト（アセスメント・ケアプラン等）があり、E2EのgetByText/getByRoleが2要素にマッチしてstrict mode violationになっていた
- `data-testid="tab-navigation"` でタブナビを一意に特定し、セレクターのスコープを限定することで修正

## 根本原因

```
WorkflowStepper  → <span>アセスメント</span>（hidden sm:block）
タブナビゲーション → <span>アセスメント</span>（hidden sm:inline）
```

Playwright の `getByText('アセスメント', { exact: true })` が両方の span にマッチ

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `App.tsx` | タブnav divに `data-testid="tab-navigation"` 追加 |
| `e2e/helpers.ts` | `switchTab` を `[data-testid="tab-navigation"]` にスコープ |
| `e2e/02-client-registration.spec.ts` | `getByRole('button', { name: 'アセスメント' })` を同コンテナにスコープ |

## Test plan

- [x] `npm run build` → 成功
- [ ] CI E2E Tests → グリーンになることを確認

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)