### PR TITLE
feat: AIケアプラン自動点検機能を実装

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ShieldCheck, FileText, Users, Menu, Sparkles, Info, AlertCircle, Plus, Trash2, Wand2, Loader2, ArrowDownCircle, Activity, Save, FolderOpen, ChevronDown, Check, History } from 'lucide-react';
-import { CareLevel, CarePlan, CarePlanNeed, AssessmentData, AppSettings, CareGoal, HospitalAdmissionSheet, IssueSummarySheet } from './types';
+import { CareLevel, CarePlan, CarePlanNeed, AssessmentData, AppSettings, CareGoal, HospitalAdmissionSheet, IssueSummarySheet, CarePlanReviewResult } from './types';
 import type { Client } from './types';
 import { validateCarePlanFull } from './services/complianceService';
-import { refineCareGoal, generateCarePlanV2 } from './services/geminiService';
+import { refineCareGoal, generateCarePlanV2, reviewCarePlan } from './services/geminiService';
 import type { CarePlanV2Response } from './services/geminiService';
 import { LifeHistoryCard, MenuDrawer, FeedbackFAB, OnboardingTour, OfflineBanner } from './components/common';
 import { NextActionBanner } from './components/common/NextActionBanner';
@@ -15,7 +15,7 @@ import { TouchAssessment } from './components/assessment';
 import { LoginScreen } from './components/auth';
 import { useAuth } from './contexts/AuthContext';
 import { useClient } from './contexts/ClientContext';
-import { PrintPreview, CarePlanSelector, CarePlanStatusBar, CarePlanV2Editor, WeeklyScheduleEditor } from './components/careplan';
+import { PrintPreview, CarePlanSelector, CarePlanStatusBar, CarePlanV2Editor, WeeklyScheduleEditor, CarePlanReviewPanel } from './components/careplan';
 import { saveAssessment, listAssessments, getAssessment, deleteAssessment, AssessmentDocument, logUsage, saveCareManagerProfile, getCareManagerProfile, CareManagerProfileData, listCarePlanHistory, CarePlanHistoryEntry, resetDemoData } from './services/firebase';
 import { useCarePlan } from './hooks/useCarePlan';
 import { useOnboarding } from './hooks/useOnboarding';
@@ -100,6 +100,10 @@ export default function App() {
   // Phase 7: Draft Prompt State
   const [draftPrompt, setDraftPrompt] = useState('');
   const [generatedDraft, setGeneratedDraft] = useState<CarePlanV2Response | null>(null);
+
+  // ケアプラン自動点検
+  const [reviewResult, setReviewResult] = useState<CarePlanReviewResult | null>(null);
+  const [reviewLoading, setReviewLoading] = useState(false);
 
   // Phase 2: Assessment Persistence State
   const [currentAssessmentId, setCurrentAssessmentId] = useState<string | null>(null);
@@ -458,6 +462,24 @@ export default function App() {
       setSaveMessage({ type: 'error', text: 'AIケアプラン作成に失敗しました。再度お試しください' });
     } finally {
       setDraftingLoading(false);
+    }
+  };
+
+  const handleReviewCarePlan = async () => {
+    if (!plan.needs || plan.needs.length === 0) {
+      setSaveMessage({ type: 'error', text: 'ケアプラン（第2表）にニーズが設定されていません。先にAI作成または手動入力してください。' });
+      return;
+    }
+    setReviewLoading(true);
+    try {
+      const result = await reviewCarePlan(assessment, plan.needs, plan.totalDirectionPolicy);
+      if (user) logUsage(user.uid, 'review_careplan');
+      setReviewResult(result);
+    } catch (error) {
+      console.error('Review Error:', error);
+      setSaveMessage({ type: 'error', text: 'ケアプラン点検に失敗しました。再度お試しください。' });
+    } finally {
+      setReviewLoading(false);
     }
   };
 
@@ -1250,6 +1272,47 @@ export default function App() {
                                 </div>
                             </div>
                         )}
+                    </div>
+                  </div>
+
+                  {/* AIケアプラン点検 */}
+                  <div className="border-t pt-6 border-stone-100">
+                    <div className="bg-gradient-to-r from-teal-50 to-cyan-50 p-4 rounded-xl border border-teal-100 mb-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <h3 className="font-bold text-teal-900 flex items-center gap-2 text-sm">
+                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                          </svg>
+                          AIケアプラン点検
+                        </h3>
+                        <button
+                          onClick={handleReviewCarePlan}
+                          disabled={reviewLoading || !plan.needs || plan.needs.length === 0}
+                          className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-bold text-white bg-teal-600 hover:bg-teal-700 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {reviewLoading ? (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                          ) : (
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                          )}
+                          {reviewLoading ? '点検中...' : '点検する'}
+                        </button>
+                      </div>
+                      <p className="text-xs text-teal-700">
+                        ゴールデンスレッド・記載表現・目標の具体性などをAIがチェックします。第2表を入力後に実行してください。
+                      </p>
+                      {reviewResult && !reviewLoading && (
+                        <div className="mt-3">
+                          <CarePlanReviewPanel
+                            result={reviewResult}
+                            isLoading={reviewLoading}
+                            onReview={handleReviewCarePlan}
+                            onClose={() => setReviewResult(null)}
+                          />
+                        </div>
+                      )}
                     </div>
                   </div>
 

--- a/components/careplan/CarePlanReviewPanel.tsx
+++ b/components/careplan/CarePlanReviewPanel.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { CheckCircle, AlertTriangle, XCircle, Info, X, RefreshCw } from 'lucide-react';
+import type { CarePlanReviewResult, CarePlanReviewItem, ReviewSeverity } from '../../types';
+
+interface CarePlanReviewPanelProps {
+  result: CarePlanReviewResult;
+  isLoading: boolean;
+  onReview: () => void;
+  onClose: () => void;
+}
+
+const SEVERITY_CONFIG: Record<ReviewSeverity, {
+  icon: React.ReactNode;
+  label: string;
+  rowClass: string;
+  badgeClass: string;
+}> = {
+  ok: {
+    icon: <CheckCircle className="w-4 h-4 text-green-600 flex-shrink-0" />,
+    label: 'OK',
+    rowClass: 'border-green-100 bg-green-50',
+    badgeClass: 'bg-green-100 text-green-700',
+  },
+  info: {
+    icon: <Info className="w-4 h-4 text-blue-500 flex-shrink-0" />,
+    label: '参考',
+    rowClass: 'border-blue-100 bg-blue-50',
+    badgeClass: 'bg-blue-100 text-blue-700',
+  },
+  warning: {
+    icon: <AlertTriangle className="w-4 h-4 text-amber-500 flex-shrink-0" />,
+    label: '要確認',
+    rowClass: 'border-amber-100 bg-amber-50',
+    badgeClass: 'bg-amber-100 text-amber-700',
+  },
+  error: {
+    icon: <XCircle className="w-4 h-4 text-red-500 flex-shrink-0" />,
+    label: '修正推奨',
+    rowClass: 'border-red-100 bg-red-50',
+    badgeClass: 'bg-red-100 text-red-700',
+  },
+};
+
+function ScoreGauge({ score }: { score: number }) {
+  const color =
+    score >= 90 ? 'text-green-600' :
+    score >= 75 ? 'text-blue-600' :
+    score >= 60 ? 'text-amber-600' :
+    'text-red-600';
+
+  const barColor =
+    score >= 90 ? 'bg-green-500' :
+    score >= 75 ? 'bg-blue-500' :
+    score >= 60 ? 'bg-amber-500' :
+    'bg-red-500';
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className={`text-3xl font-bold ${color}`}>{score}</span>
+      <div className="flex-1">
+        <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className={`h-full ${barColor} rounded-full transition-all duration-700`}
+            style={{ width: `${score}%` }}
+          />
+        </div>
+        <p className="text-xs text-gray-400 mt-0.5">/ 100点</p>
+      </div>
+    </div>
+  );
+}
+
+function ReviewItemCard({ item }: { item: CarePlanReviewItem }) {
+  const config = SEVERITY_CONFIG[item.severity];
+  return (
+    <div className={`border rounded-lg p-3 ${config.rowClass}`}>
+      <div className="flex items-start gap-2">
+        {config.icon}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap mb-1">
+            <span className={`text-xs font-bold px-1.5 py-0.5 rounded ${config.badgeClass}`}>
+              {config.label}
+            </span>
+            <span className="text-xs font-medium text-gray-500">{item.category}</span>
+            <span className="text-xs text-gray-400">｜ {item.target}</span>
+          </div>
+          <p className="text-sm text-gray-800">{item.message}</p>
+          {item.suggestion && (
+            <p className="text-xs text-gray-600 mt-1 pl-2 border-l-2 border-gray-300">
+              💡 {item.suggestion}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const CarePlanReviewPanel: React.FC<CarePlanReviewPanelProps> = ({
+  result,
+  isLoading,
+  onReview,
+  onClose,
+}) => {
+  const errorCount = result.items.filter((i) => i.severity === 'error').length;
+  const warningCount = result.items.filter((i) => i.severity === 'warning').length;
+
+  return (
+    <div className="bg-white border border-violet-200 rounded-xl shadow-sm animate-in fade-in slide-in-from-top-2">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-violet-100 bg-violet-50 rounded-t-xl">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-bold text-violet-900">AI点検結果</span>
+          <span className="text-xs text-violet-600 bg-violet-100 px-1.5 py-0.5 rounded">
+            {new Date(result.checkedAt).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })} 点検
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onReview}
+            disabled={isLoading}
+            className="flex items-center gap-1 text-xs text-violet-600 hover:text-violet-800 disabled:opacity-50 px-2 py-1 hover:bg-violet-100 rounded"
+          >
+            <RefreshCw className={`w-3 h-3 ${isLoading ? 'animate-spin' : ''}`} />
+            再点検
+          </button>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-violet-100 rounded text-violet-500 hover:text-violet-700"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* スコア + サマリー */}
+      <div className="px-4 py-3 border-b border-gray-100">
+        <div className="flex items-start gap-4">
+          <div className="min-w-[120px]">
+            <p className="text-xs text-gray-500 mb-1">総合スコア</p>
+            <ScoreGauge score={result.overallScore} />
+          </div>
+          <div className="flex-1">
+            <p className="text-xs text-gray-500 mb-1">総合評価</p>
+            <p className="text-sm text-gray-800">{result.overallComment}</p>
+            {(errorCount > 0 || warningCount > 0) && (
+              <div className="flex gap-2 mt-2">
+                {errorCount > 0 && (
+                  <span className="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded-full font-medium">
+                    修正推奨 {errorCount}件
+                  </span>
+                )}
+                {warningCount > 0 && (
+                  <span className="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full font-medium">
+                    要確認 {warningCount}件
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 個別指摘 */}
+      <div className="px-4 py-3 space-y-2 max-h-80 overflow-y-auto">
+        {result.items.map((item, idx) => (
+          <ReviewItemCard key={idx} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/components/careplan/index.ts
+++ b/components/careplan/index.ts
@@ -5,3 +5,4 @@ export { CarePlanV2Editor } from './CarePlanV2Editor';
 export { NeedEditor } from './NeedEditor';
 export { WeeklyScheduleEditor } from './WeeklyScheduleEditor';
 export { WeeklySchedulePreview } from './WeeklySchedulePreview';
+export { CarePlanReviewPanel } from './CarePlanReviewPanel';

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ export {
   refineCareGoal,
   generateCarePlanDraft,
   generateCarePlanV2, // 拡張版（第2表完全対応）
+  reviewCarePlan, // ケアプラン自動点検
 } from './vertexAi';
 
 // デモデータリセット

--- a/functions/src/prompts/reviewPrompt.ts
+++ b/functions/src/prompts/reviewPrompt.ts
@@ -1,0 +1,144 @@
+/**
+ * ケアプラン点検プロンプト
+ * アセスメントと第2表（ニーズ・目標・サービス）の品質をチェック
+ */
+
+interface AssessmentData {
+  serviceHistory?: string;
+  healthStatus?: string;
+  pastHistory?: string;
+  skinCondition?: string;
+  oralHygiene?: string;
+  fluidIntake?: string;
+  adlTransfer?: string;
+  adlEating?: string;
+  adlToileting?: string;
+  adlBathing?: string;
+  adlDressing?: string;
+  iadlCooking?: string;
+  iadlShopping?: string;
+  iadlMoney?: string;
+  medication?: string;
+  cognition?: string;
+  communication?: string;
+  socialParticipation?: string;
+  residence?: string;
+  familySituation?: string;
+  maltreatmentRisk?: string;
+  environment?: string;
+}
+
+interface CarePlanNeed {
+  content: string;
+  longTermGoal: string;
+  shortTermGoals: { content: string }[];
+  services: { content: string; type: string; frequency: string }[];
+}
+
+interface ReviewInput {
+  assessment: AssessmentData;
+  needs: CarePlanNeed[];
+  totalDirectionPolicy?: string;
+}
+
+/**
+ * ケアプラン点検プロンプトを構築する
+ */
+export function buildReviewPrompt(input: ReviewInput): string {
+  const { assessment, needs, totalDirectionPolicy } = input;
+
+  const needsJson = JSON.stringify(
+    needs.map((n, i) => ({
+      id: `ニーズ${i + 1}`,
+      content: n.content,
+      longTermGoal: n.longTermGoal,
+      shortTermGoals: n.shortTermGoals.map((g) => g.content),
+      services: n.services.map((s) => `[${s.type}] ${s.content}（${s.frequency}）`),
+    })),
+    null,
+    2
+  );
+
+  return `あなたは2025年時点の日本の介護保険制度に精通した、第三者評価・実地指導にも精通した熟練ケアマネジャーです。
+以下のアセスメント情報とケアプラン（第2表）を照合し、品質を点検してください。
+
+【アセスメント情報（23項目）】
+${JSON.stringify(assessment, null, 2)}
+
+【総合的な援助の方針（第1表）】
+${totalDirectionPolicy || '（未記入）'}
+
+【ケアプラン第2表（ニーズ・目標・サービス）】
+${needsJson}
+
+---
+
+【点検の観点（6項目）】
+
+1. **ゴールデンスレッド（一貫性）**
+   - アセスメントで確認された課題・ニーズがケアプランに反映されているか
+   - ニーズ → 長期目標 → 短期目標 → サービス内容 の論理的つながり
+
+2. **記載表現の適切性**
+   - ニーズ（生活全般の解決すべき課題）: 利用者主語・願望形「〜したい」「〜でいたい」
+   - 長期目標: 利用者主語・達成形「〜できる」「〜を維持できる」
+   - 短期目標: 具体的行動目標「週◯回〜する」（数値・条件付き）
+
+3. **目標の具体性（SMART原則）**
+   - Specific（具体的か）
+   - Measurable（測定可能か：週◯回、◯m歩行など）
+   - Achievable（達成可能か）
+   - Relevant（ニーズと関連しているか）
+   - Time-bound（期間・タイムラインが示されているか）
+
+4. **長期目標と短期目標の整合性**
+   - 短期目標が長期目標達成への段階的ステップになっているか
+   - 短期目標の積み重ねで長期目標に到達できる構造か
+
+5. **サービス内容の妥当性**
+   - 設定されたサービスがニーズ・目標に対応しているか
+   - 頻度・内容が現実的か
+   - 複数のサービスが重複・矛盾していないか
+
+6. **必須項目の充足**
+   - ニーズ、長期目標、短期目標が空欄でないか
+   - 最低1つのサービスが設定されているか
+
+---
+
+【出力形式】
+
+必ず以下のJSONスキーマに従って出力すること。
+
+\`\`\`json
+{
+  "overallScore": <整数 0-100>,
+  "overallComment": "<総合評価コメント（1-3文）>",
+  "items": [
+    {
+      "category": "<点検カテゴリ名>",
+      "target": "<対象（例: ニーズ1, 短期目標2, 全体）>",
+      "severity": "<ok|info|warning|error>",
+      "message": "<指摘内容>",
+      "suggestion": "<改善提案（任意）>"
+    }
+  ]
+}
+\`\`\`
+
+severityの基準:
+- ok: 問題なし・良好
+- info: 参考情報・軽微な確認点
+- warning: 要確認・改善を推奨
+- error: 法令上の問題・修正が必要
+
+overallScoreの目安:
+- 90-100: 優秀・すぐに使用可能
+- 75-89: 良好・軽微な修正推奨
+- 60-74: 要改善・主要な問題点あり
+- 60未満: 大幅な修正が必要
+
+必ずすべての点検観点（6項目）に対して少なくとも1件のitemsエントリを含めること。
+問題がない場合も severity: "ok" で記録すること。
+itemsは重要度の高いもの（error > warning > info > ok）から並べること。`;
+}

--- a/functions/src/vertexAi.ts
+++ b/functions/src/vertexAi.ts
@@ -2,6 +2,7 @@ import { VertexAI, SchemaType, type Content } from '@google-cloud/vertexai';
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions';
 import { buildCarePlanPrompt } from './prompts/careplanPrompt';
+import { buildReviewPrompt } from './prompts/reviewPrompt';
 
 const PROJECT_ID = 'caremanager-ai-copilot-486212';
 const LOCATION = 'asia-northeast1';
@@ -529,6 +530,106 @@ export const generateCarePlanV2 = onCall<GenerateCarePlanDraftRequest>(
 
       const classified = classifyVertexError(error);
       throw new HttpsError(classified.code, `ケアプラン生成中にエラーが発生しました: ${classified.message}`);
+    }
+  }
+);
+
+// ケアプラン点検スキーマ
+const carePlanReviewSchema = {
+  type: SchemaType.OBJECT,
+  properties: {
+    overallScore: {
+      type: SchemaType.INTEGER,
+      description: '総合スコア (0-100)',
+    },
+    overallComment: {
+      type: SchemaType.STRING,
+      description: '総合評価コメント（1-3文）',
+    },
+    items: {
+      type: SchemaType.ARRAY,
+      description: '個別点検結果',
+      items: {
+        type: SchemaType.OBJECT,
+        properties: {
+          category: { type: SchemaType.STRING, description: '点検カテゴリ名' },
+          target: { type: SchemaType.STRING, description: '指摘対象（例: ニーズ1, 短期目標2, 全体）' },
+          severity: {
+            type: SchemaType.STRING,
+            description: '重要度: ok|info|warning|error',
+            enum: ['ok', 'info', 'warning', 'error'],
+          },
+          message: { type: SchemaType.STRING, description: '指摘内容' },
+          suggestion: { type: SchemaType.STRING, description: '改善提案（任意）' },
+        },
+        required: ['category', 'target', 'severity', 'message'],
+      },
+    },
+  },
+  required: ['overallScore', 'overallComment', 'items'],
+};
+
+/**
+ * ケアプラン自動点検
+ * アセスメントと第2表（ニーズ・目標・サービス）を照合し品質チェック
+ */
+export const reviewCarePlan = onCall(
+  {
+    region: 'asia-northeast1',
+    memory: '512MiB',
+    timeoutSeconds: 120,
+    cors: true,
+  },
+  async (request) => {
+    logger.info('reviewCarePlan: start', { uid: request.auth?.uid });
+
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', '認証が必要です');
+    }
+
+    const { assessment, needs, totalDirectionPolicy } = request.data;
+
+    if (!assessment || !needs) {
+      throw new HttpsError('invalid-argument', 'アセスメントデータとケアプランデータが必要です');
+    }
+
+    try {
+      const prompt = buildReviewPrompt({ assessment, needs, totalDirectionPolicy });
+
+      const result = await model.generateContent({
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        generationConfig: {
+          responseMimeType: 'application/json',
+          responseSchema: carePlanReviewSchema,
+        },
+      });
+
+      const responseText = result.response.candidates?.[0]?.content?.parts?.[0]?.text;
+
+      if (!responseText) {
+        throw new HttpsError('internal', 'AIからの応答がありません');
+      }
+
+      const parsed = JSON.parse(responseText);
+
+      logger.info('reviewCarePlan: completed', {
+        score: parsed.overallScore,
+        itemCount: parsed.items?.length,
+      });
+
+      return {
+        ...parsed,
+        checkedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      logger.error('reviewCarePlan error:', error);
+
+      if (error instanceof HttpsError) {
+        throw error;
+      }
+
+      const classified = classifyVertexError(error);
+      throw new HttpsError(classified.code, `ケアプラン点検中にエラーが発生しました: ${classified.message}`);
     }
   }
 );

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -6,7 +6,7 @@
  * 移行後: Cloud Functions for Firebase → Vertex AI (asia-northeast1)
  */
 
-import { AssessmentData } from '../types';
+import { AssessmentData, CarePlanNeed, CarePlanReviewResult } from '../types';
 import { analyzeAssessment as callAnalyzeAssessment, functions } from './firebase';
 import { httpsCallable } from 'firebase/functions';
 
@@ -176,6 +176,52 @@ export const generateCarePlanV2 = async (
     return result.data;
   } catch (error) {
     console.error('Plan V2 Generation Error:', error);
+    throw error;
+  }
+};
+
+// ケアプラン点検リクエスト型
+interface ReviewCarePlanRequest {
+  assessment: AssessmentData;
+  needs: Pick<CarePlanNeed, 'content' | 'longTermGoal' | 'shortTermGoals' | 'services'>[];
+  totalDirectionPolicy?: string;
+}
+
+const reviewCarePlanFn = httpsCallable<ReviewCarePlanRequest, CarePlanReviewResult>(
+  functions,
+  'reviewCarePlan'
+);
+
+/**
+ * reviewCarePlan
+ * ケアプラン（第2表）の品質をAIで点検する
+ *
+ * - アセスメントとニーズ・目標・サービスの整合性チェック
+ * - 記載表現・SMART原則・ゴールデンスレッドの確認
+ * - 総合スコア（0-100）と個別指摘事項を返す
+ */
+export const reviewCarePlan = async (
+  assessment: AssessmentData,
+  needs: CarePlanNeed[],
+  totalDirectionPolicy?: string
+): Promise<CarePlanReviewResult> => {
+  // Cloud Functionsに送るために必要なフィールドのみ抽出
+  const needsForReview = needs.map((n) => ({
+    content: n.content,
+    longTermGoal: n.longTermGoal,
+    shortTermGoals: n.shortTermGoals.map((g) => ({ content: g.content })),
+    services: n.services.map((s) => ({
+      content: s.content,
+      type: s.type,
+      frequency: s.frequency,
+    })),
+  }));
+
+  try {
+    const result = await reviewCarePlanFn({ assessment, needs: needsForReview, totalDirectionPolicy });
+    return result.data;
+  } catch (error) {
+    console.error('Care Plan Review Error:', error);
     throw error;
   }
 };

--- a/tests/utils/reviewPrompt.test.ts
+++ b/tests/utils/reviewPrompt.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { buildReviewPrompt } from '../../functions/src/prompts/reviewPrompt';
+
+const mockAssessment = {
+  serviceHistory: 'デイサービス週3回利用中',
+  healthStatus: '高血圧・糖尿病あり',
+  pastHistory: '脳梗塞（2020年）',
+  adlTransfer: '一部介助で可能',
+  adlEating: '自立',
+  adlBathing: '全介助',
+  cognition: '認知症の診断あり',
+  familySituation: '娘が同居、介護力あり',
+};
+
+const mockNeeds = [
+  {
+    content: '入浴時に全介助が必要だが、自宅での入浴を続けたい',
+    longTermGoal: '安全に入浴できる環境を整え、清潔を保ちながら自宅生活を継続できる',
+    shortTermGoals: [
+      { content: '週2回の訪問介護による入浴介助を受ける' },
+    ],
+    services: [
+      { content: '入浴介助・身体整容', type: '訪問介護', frequency: '週2回' },
+    ],
+  },
+];
+
+// ========================================
+// buildReviewPrompt テスト
+// ========================================
+
+describe('buildReviewPrompt', () => {
+  it('プロンプト文字列が生成される', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: mockNeeds });
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(100);
+  });
+
+  it('アセスメント情報がプロンプトに含まれる', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: mockNeeds });
+    expect(prompt).toContain('高血圧・糖尿病あり');
+    expect(prompt).toContain('認知症の診断あり');
+  });
+
+  it('ニーズ情報がプロンプトに含まれる', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: mockNeeds });
+    expect(prompt).toContain('入浴時に全介助が必要');
+    expect(prompt).toContain('週2回の訪問介護による入浴介助');
+  });
+
+  it('totalDirectionPolicyが指定された場合にプロンプトに含まれる', () => {
+    const prompt = buildReviewPrompt({
+      assessment: mockAssessment,
+      needs: mockNeeds,
+      totalDirectionPolicy: '在宅生活継続を最優先とし、家族への負担軽減を図る',
+    });
+    expect(prompt).toContain('在宅生活継続を最優先');
+  });
+
+  it('totalDirectionPolicyが未指定の場合は（未記入）と表示', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: mockNeeds });
+    expect(prompt).toContain('（未記入）');
+  });
+
+  it('6つの点検観点がプロンプトに含まれる', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: mockNeeds });
+    expect(prompt).toContain('ゴールデンスレッド');
+    expect(prompt).toContain('記載表現');
+    expect(prompt).toContain('SMART');
+    expect(prompt).toContain('長期目標と短期目標の整合性');
+    expect(prompt).toContain('サービス内容の妥当性');
+    expect(prompt).toContain('必須項目の充足');
+  });
+
+  it('JSONスキーマ出力形式がプロンプトに含まれる', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: mockNeeds });
+    expect(prompt).toContain('overallScore');
+    expect(prompt).toContain('overallComment');
+    expect(prompt).toContain('items');
+    expect(prompt).toContain('severity');
+  });
+
+  it('severity の選択肢が明記されている', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: mockNeeds });
+    expect(prompt).toContain('ok|info|warning|error');
+  });
+
+  it('複数ニーズを正しくシリアライズする', () => {
+    const multiNeeds = [
+      ...mockNeeds,
+      {
+        content: '食事は自立しているが、栄養管理が難しい',
+        longTermGoal: 'バランスの良い食事を継続できる',
+        shortTermGoals: [{ content: '管理栄養士による栄養相談を月1回受ける' }],
+        services: [{ content: '栄養相談', type: '居宅療養管理指導', frequency: '月1回' }],
+      },
+    ];
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: multiNeeds });
+    expect(prompt).toContain('ニーズ1');
+    expect(prompt).toContain('ニーズ2');
+    expect(prompt).toContain('食事は自立しているが、栄養管理が難しい');
+  });
+
+  it('空のニーズ配列でもエラーにならない', () => {
+    const prompt = buildReviewPrompt({ assessment: mockAssessment, needs: [] });
+    expect(typeof prompt).toBe('string');
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -497,3 +497,36 @@ export interface IssueSummarySheet {
   careManagerOffice: string;
   rows: IssueSummaryRow[];
 }
+
+// ------------------------------------------------------------------
+// Care Plan Review (AI自動点検)
+// ------------------------------------------------------------------
+
+/** 点検結果の重要度 */
+export type ReviewSeverity = 'ok' | 'info' | 'warning' | 'error';
+
+/** 点検結果の個別指摘項目 */
+export interface CarePlanReviewItem {
+  /** 点検カテゴリ（例: 'ゴールデンスレッド', '記載表現'） */
+  category: string;
+  /** 指摘対象（例: 'ニーズ1', '短期目標2'） */
+  target: string;
+  /** 重要度 */
+  severity: ReviewSeverity;
+  /** 指摘内容 */
+  message: string;
+  /** 改善提案（任意） */
+  suggestion?: string;
+}
+
+/** ケアプラン点検結果 */
+export interface CarePlanReviewResult {
+  /** 総合スコア (0-100) */
+  overallScore: number;
+  /** 総合コメント */
+  overallComment: string;
+  /** 個別指摘事項 */
+  items: CarePlanReviewItem[];
+  /** 点検日時 */
+  checkedAt: string;
+}


### PR DESCRIPTION
## Summary

- ケアプラン（第2表）作成後に「点検する」ボタン1つでAIが品質チェックを実行
- アセスメントとニーズ・目標・サービスの整合性を6観点で評価し、総合スコア（0-100）と個別指摘事項を表示
- ゴールデンスレッド・記載表現・SMART原則・目標整合性・サービス妥当性・必須項目充足を網羅

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `types.ts` | `ReviewSeverity` / `CarePlanReviewItem` / `CarePlanReviewResult` 型追加 |
| `functions/src/prompts/reviewPrompt.ts` | 6観点の点検プロンプト（新規） |
| `functions/src/vertexAi.ts` | `reviewCarePlan` Cloud Function（512MiB/120s） |
| `functions/src/index.ts` | `reviewCarePlan` エクスポート追加 |
| `services/geminiService.ts` | `reviewCarePlan` クライアント関数追加 |
| `components/careplan/CarePlanReviewPanel.tsx` | ScoreGauge + ReviewItemCard + パネルUI（新規） |
| `App.tsx` | state・ハンドラ・UIセクション統合 |
| `tests/utils/reviewPrompt.test.ts` | `buildReviewPrompt` 単体テスト 9件（新規） |

## Test plan

- [x] `buildReviewPrompt` 単体テスト 9件追加・全パス
- [x] 既存テスト 275件全パス（回帰なし）
- [x] functions ビルド成功（tsc エラーなし）
- [x] フロントエンドビルド成功（1781モジュール）
- [ ] 本番デプロイ後: `reviewCarePlan` Cloud Function のデプロイ確認
- [ ] 実機: 第2表入力 → 「点検する」ボタン → スコア + 指摘一覧が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)