### PR TITLE
fix(careplan): 第1表・第2表を厚生労働省公式様式に完全準拠（table-layout:fixed + colgroup調整）

### DIFF
--- a/components/careplan/PrintPreview.tsx
+++ b/components/careplan/PrintPreview.tsx
@@ -46,7 +46,7 @@ const formatJaDate = (dateStr: string | null | undefined): string => {
 };
 
 /** 期間文字列を生成（開始日〜終了日）*/
-const formatPeriod = (start?: string, end?: string): string => {
+const formatPeriod = (start?: string | null, end?: string | null): string => {
   const s = formatJaDate(start);
   const e = formatJaDate(end);
   if (s && e) return `${s}〜${e}`;
@@ -55,186 +55,132 @@ const formatPeriod = (start?: string, end?: string): string => {
   return '';
 };
 
+/** 要介護状態区分の表示（公式様式通り 要介護１〜５ with 選択を○囲み）*/
+const CARE_LEVELS = ['要介護１', '要介護２', '要介護３', '要介護４', '要介護５'];
+const CARE_LEVEL_MAP: Record<string, string> = {
+  '要介護1': '要介護１',
+  '要介護2': '要介護２',
+  '要介護3': '要介護３',
+  '要介護4': '要介護４',
+  '要介護5': '要介護５',
+};
+
 export const PrintPreview: React.FC<Props> = ({ isOpen, onClose, user, plan, assessment: _assessment, careManagerInfo }) => {
   const printRef = useRef<HTMLDivElement>(null);
 
   if (!isOpen) return null;
 
-  const planCreationDate = formatJaDate(plan.planCreationDate ?? plan.draftDate);
+  const planDate = formatJaDate(plan.planCreationDate ?? plan.draftDate);
+  const currentCareLevel = CARE_LEVEL_MAP[user.careLevel] ?? user.careLevel;
+
+  // ---- 印刷用HTMLの共通スタイル ----
+  const PRINT_STYLES = `
+    @media print {
+      @page { margin: 8mm; size: A4 portrait; }
+      @page sheet2 { size: A4 landscape; margin: 8mm; }
+      @page sheet3 { size: A4 landscape; margin: 8mm; }
+      .sheet2 { page: sheet2; }
+      .sheet3 { page: sheet3; }
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+      font-size: 9pt;
+      line-height: 1.4;
+      color: #1a1a1a;
+      margin: 0;
+      padding: 6px;
+    }
+    .page-break { page-break-before: always; padding-top: 6px; }
+
+    /* 第1表・共通テーブル */
+    .f-table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+    .f-table th, .f-table td {
+      border: 1px solid #333;
+      padding: 3px 5px;
+      vertical-align: top;
+      font-size: 8.5pt;
+    }
+    .f-table th { background: #f0f0f0; font-weight: bold; }
+
+    /* 第1表 ヘッダーエリア */
+    .s1-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 3px;
+    }
+    .s1-tag {
+      border: 1px solid #333;
+      padding: 1px 6px;
+      font-size: 9pt;
+      font-weight: bold;
+      white-space: nowrap;
+    }
+    .s1-title { font-size: 14pt; font-weight: bold; text-align: center; flex: 1; }
+    .s1-meta { text-align: right; font-size: 8pt; white-space: nowrap; min-width: 140px; }
+    .s1-insurer { display: flex; gap: 12px; justify-content: flex-end; font-size: 8pt; margin-bottom: 2px; }
+
+    /* 丸囲み選択済み */
+    .sel {
+      display: inline-block;
+      border: 1.5px solid #333;
+      border-radius: 9999px;
+      padding: 0 4px;
+      font-weight: bold;
+    }
+
+    /* 第2表 */
+    .s2-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 3px;
+    }
+    .n-table { width: 100%; border-collapse: collapse; }
+    .n-table th, .n-table td {
+      border: 1px solid #333;
+      padding: 2px 3px;
+      vertical-align: top;
+      font-size: 7.5pt;
+    }
+    .n-table th { background: #f0f0f0; font-weight: bold; text-align: center; }
+    .footnote { font-size: 7pt; color: #444; margin-top: 3px; }
+
+    /* 第3表 */
+    .w-table { width: 100%; border-collapse: collapse; }
+    .w-table th, .w-table td {
+      border: 1px solid #333;
+      padding: 2px 3px;
+      vertical-align: top;
+      font-size: 7.5pt;
+    }
+    .w-table th { background: #f0f0f0; font-weight: bold; text-align: center; }
+  `;
 
   const handlePrint = () => {
     const printContent = printRef.current;
     if (!printContent) return;
-
     const printWindow = window.open('', '_blank');
     if (!printWindow) return;
-
-    printWindow.document.write(`
-      <!DOCTYPE html>
-      <html lang="ja">
-      <head>
-        <meta charset="UTF-8">
-        <title>居宅サービス計画書</title>
-        <style>
-          @media print {
-            @page { margin: 8mm; size: A4 portrait; }
-            @page sheet2 { size: A4 landscape; margin: 8mm; }
-            @page sheet3 { size: A4 landscape; margin: 8mm; }
-            .sheet2 { page: sheet2; }
-            .sheet3 { page: sheet3; }
-          }
-          * { box-sizing: border-box; }
-          body {
-            font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
-            font-size: 9pt;
-            line-height: 1.4;
-            color: #1a1a1a;
-            margin: 0;
-            padding: 8px;
-          }
-          .page-break {
-            page-break-before: always;
-            padding-top: 8px;
-          }
-          /* シートタイトルエリア */
-          .sheet-title-area {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-end;
-            margin-bottom: 4px;
-          }
-          .sheet-title {
-            font-size: 13pt;
-            font-weight: bold;
-            text-align: center;
-            flex: 1;
-          }
-          .sheet-meta {
-            font-size: 7.5pt;
-            text-align: right;
-            white-space: nowrap;
-            min-width: 130px;
-          }
-          /* 第1表・第2表 共通テーブル */
-          .form-table {
-            width: 100%;
-            border-collapse: collapse;
-          }
-          .form-table th,
-          .form-table td {
-            border: 1px solid #333;
-            padding: 4px 6px;
-            vertical-align: top;
-            font-size: 9pt;
-          }
-          .form-table th {
-            background: #f0f0f0;
-            font-weight: bold;
-            white-space: nowrap;
-          }
-          .form-table .tall-cell {
-            height: 56px;
-          }
-          .form-table .xl-cell {
-            height: 72px;
-          }
-          /* 丸囲み（選択済み）*/
-          .sel {
-            display: inline-block;
-            border: 1.5px solid #333;
-            border-radius: 9999px;
-            padding: 0 4px;
-            font-weight: bold;
-          }
-          .note-text {
-            font-size: 7pt;
-            color: #666;
-          }
-          /* 第2表ニーズテーブル */
-          .needs-table {
-            width: 100%;
-            border-collapse: collapse;
-          }
-          .needs-table th,
-          .needs-table td {
-            border: 1px solid #333;
-            padding: 3px 4px;
-            vertical-align: top;
-            font-size: 8pt;
-          }
-          .needs-table th {
-            background: #f0f0f0;
-            font-weight: bold;
-            text-align: center;
-            white-space: normal;
-          }
-          .needs-table .center { text-align: center; }
-          .needs-table .small { font-size: 7pt; }
-          /* ヘッダー行（第2表） */
-          .sheet2-header {
-            display: flex;
-            justify-content: space-between;
-            margin-bottom: 4px;
-            font-size: 9pt;
-          }
-          /* 注釈 */
-          .footnote {
-            font-size: 7.5pt;
-            color: #444;
-            margin-top: 4px;
-          }
-          /* フッター */
-          .sheet-footer {
-            text-align: right;
-            font-size: 7pt;
-            color: #aaa;
-            margin-top: 6px;
-          }
-          /* 第3表 */
-          .weekly-table {
-            width: 100%;
-            border-collapse: collapse;
-          }
-          .weekly-table th,
-          .weekly-table td {
-            border: 1px solid #333;
-            padding: 3px 4px;
-            vertical-align: top;
-            font-size: 8pt;
-          }
-          .weekly-table th {
-            background: #f0f0f0;
-            font-weight: bold;
-            text-align: center;
-          }
-          .weekly-table .day-mark { text-align: center; }
-        </style>
-      </head>
-      <body>
-        ${printContent.innerHTML}
-      </body>
-      </html>
-    `);
+    printWindow.document.write(`<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><title>居宅サービス計画書</title><style>${PRINT_STYLES}</style></head><body>${printContent.innerHTML}</body></html>`);
     printWindow.document.close();
     printWindow.print();
   };
 
-  /* ---- 選択肢表示ヘルパー ---- */
-  const SelectOption: React.FC<{ value: string | undefined; options: string[] }> = ({ value, options }) => (
-    <>
-      {options.map((opt, i) => (
-        <React.Fragment key={opt}>
-          {i > 0 && '・'}
-          <span className={value === opt ? 'sel' : ''}
-                style={value === opt ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' } : {}}>
-            {opt}
-          </span>
-        </React.Fragment>
-      ))}
-    </>
-  );
+  /* ---- 選択肢 丸囲み表示 ---- */
+  const Sel: React.FC<{ current: string | undefined; value: string }> = ({ current, value }) => {
+    const selected = current === value;
+    return (
+      <span
+        style={selected ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' } : {}}
+      >
+        {value}
+      </span>
+    );
+  };
 
-  /* ---- 第2表ニーズテーブル行生成 ---- */
+  /* ---- 第2表データ行生成 ---- */
   const renderNeedsRows = () => {
     if (plan.needs && plan.needs.length > 0) {
       return plan.needs.flatMap((need) => {
@@ -249,18 +195,19 @@ export const PrintPreview: React.FC<Props> = ({ isOpen, onClose, user, plan, ass
             <tr key={`${need.id}-${i}`}>
               {i === 0 && (
                 <>
-                  <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '20%' }}>{need.content}</td>
-                  <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '12%' }}>{need.longTermGoal}</td>
-                  <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '8%', fontSize: '7.5pt' }}>{ltPeriod}</td>
+                  <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '16%' }}>{need.content}</td>
+                  <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '14%' }}>{need.longTermGoal}</td>
+                  <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '8%', fontSize: '7pt' }}>{ltPeriod}</td>
                 </>
               )}
-              <td style={{ width: '11%' }}>{stGoal?.content ?? ''}</td>
-              <td style={{ width: '7%', fontSize: '7.5pt' }}>{stPeriod}</td>
-              <td style={{ width: '14%' }}>{svc?.content ?? ''}</td>
-              <td style={{ width: '4%', textAlign: 'center' }}>{svc?.insuranceCovered !== false ? '○' : ''}</td>
-              <td style={{ width: '10%' }}>{svc?.provider ?? ''}</td>
-              <td style={{ width: '7%' }}>{svc?.frequency ?? ''}</td>
-              <td style={{ width: '7%', fontSize: '7.5pt' }}>{svcPeriod}</td>
+              <td style={{ width: '12%' }}>{stGoal?.content ?? ''}</td>
+              <td style={{ width: '7%', fontSize: '7pt' }}>{stPeriod}</td>
+              <td style={{ width: '13%' }}>{svc?.content ?? ''}</td>
+              <td style={{ width: '3%', textAlign: 'center' }}>{svc?.insuranceCovered !== false ? '○' : ''}</td>
+              <td style={{ width: '10%' }}>{svc?.type ?? ''}</td>
+              <td style={{ width: '7%' }}>{svc?.provider ?? ''}</td>
+              <td style={{ width: '5%' }}>{svc?.frequency ?? ''}</td>
+              <td style={{ width: '5%', fontSize: '7pt' }}>{svcPeriod}</td>
             </tr>
           );
         });
@@ -275,29 +222,40 @@ export const PrintPreview: React.FC<Props> = ({ isOpen, onClose, user, plan, ass
         <tr key={i}>
           {i === 0 && (
             <>
-              <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '20%' }}></td>
-              <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '12%' }}>{plan.longTermGoal}</td>
-              <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '8%', fontSize: '7.5pt' }}>
+              <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '16%' }}></td>
+              <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '14%' }}>{plan.longTermGoal}</td>
+              <td rowSpan={rowCount} style={{ verticalAlign: 'top', width: '8%', fontSize: '7pt' }}>
                 {formatPeriod(plan.longTermGoalStartDate, plan.longTermGoalEndDate)}
               </td>
             </>
           )}
-          <td style={{ width: '11%' }}>{stGoal?.content ?? ''}</td>
-          <td style={{ width: '7%', fontSize: '7.5pt' }}>{stPeriod}</td>
-          <td style={{ width: '14%' }}></td>
-          <td style={{ width: '4%', textAlign: 'center' }}></td>
+          <td style={{ width: '12%' }}>{stGoal?.content ?? ''}</td>
+          <td style={{ width: '7%', fontSize: '7pt' }}>{stPeriod}</td>
+          <td style={{ width: '13%' }}></td>
+          <td style={{ width: '3%', textAlign: 'center' }}></td>
           <td style={{ width: '10%' }}></td>
           <td style={{ width: '7%' }}></td>
-          <td style={{ width: '7%', fontSize: '7.5pt' }}></td>
+          <td style={{ width: '5%' }}></td>
+          <td style={{ width: '5%', fontSize: '7pt' }}></td>
         </tr>
       );
     });
   };
 
+  /* ---- 共通インラインスタイル定義 ---- */
+  const TH: React.CSSProperties = {
+    border: '1px solid #333', padding: '3px 5px', background: '#f0f0f0',
+    fontWeight: 'bold', verticalAlign: 'top', fontSize: '8.5pt',
+  };
+  const TD: React.CSSProperties = {
+    border: '1px solid #333', padding: '3px 5px', verticalAlign: 'top', fontSize: '8.5pt',
+  };
+
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50">
       <div className="bg-white rounded-xl shadow-2xl w-full max-w-5xl max-h-[90vh] overflow-hidden flex flex-col">
-        {/* ヘッダー */}
+
+        {/* ---- モーダルヘッダー ---- */}
         <div className="flex items-center justify-between p-4 border-b border-stone-200">
           <div>
             <h2 className="text-lg font-bold text-stone-800">印刷プレビュー</h2>
@@ -313,154 +271,191 @@ export const PrintPreview: React.FC<Props> = ({ isOpen, onClose, user, plan, ass
               <Printer className="w-4 h-4" />
               印刷 / PDF保存
             </button>
-            <button
-              onClick={onClose}
-              className="p-2 hover:bg-stone-100 rounded-full transition-colors"
-            >
+            <button onClick={onClose} className="p-2 hover:bg-stone-100 rounded-full transition-colors">
               <X className="w-5 h-5 text-stone-600" />
             </button>
           </div>
         </div>
 
-        {/* プレビューコンテンツ */}
+        {/* ---- プレビュー本体 ---- */}
         <div className="flex-1 overflow-auto p-6 bg-stone-100">
           <div ref={printRef} className="space-y-6">
 
-            {/* ========== 第1表: 居宅サービス計画書（1） ========== */}
-            <div className="bg-white shadow-md mx-auto p-6" style={{ maxWidth: '210mm', fontFamily: '"Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif', fontSize: '10pt' }}>
+            {/* ══════════════════════════════════════════
+                第1表: 居宅サービス計画書（１）
+                ══════════════════════════════════════════ */}
+            <div
+              className="bg-white shadow-md mx-auto p-4"
+              style={{ maxWidth: '210mm', fontFamily: '"Hiragino Kaku Gothic ProN","Hiragino Sans",Meiryo,sans-serif', fontSize: '9pt' }}
+            >
+              {/* === 第1表ヘッダーエリア === */}
+              {/* 保険者番号・被保険者番号（上部） */}
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '16px', marginBottom: '3px', fontSize: '8pt' }}>
+                <span>保険者番号　{user.insurerNumber ?? '　　　　　　　　'}</span>
+                <span>被保険者番号　{user.insuredNumber ?? '　　　　　　　　　　'}</span>
+              </div>
 
-              {/* タイトルエリア */}
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '6px' }}>
-                <div style={{ width: '20%' }}></div>
+              {/* タイトル行：第1表 ラベル | タイトル | 作成年月日 */}
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2px' }}>
+                <div style={{ border: '1px solid #333', padding: '1px 6px', fontSize: '9pt', fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+                  第１表
+                </div>
                 <div style={{ fontSize: '14pt', fontWeight: 'bold', textAlign: 'center', flex: 1 }}>
                   居宅サービス計画書（１）
                 </div>
-                <div style={{ width: '25%', textAlign: 'right', fontSize: '8pt' }}>
-                  作成年月日　{planCreationDate}<br />第１表
+                <div style={{ textAlign: 'right', fontSize: '8pt', whiteSpace: 'nowrap', minWidth: '140px' }}>
+                  作成年月日　{planDate}
                 </div>
               </div>
 
-              {/* 本体テーブル */}
-              <table className="form-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+              {/* 第2行：初回・紹介・継続 / 認定済・申請中（右寄せ） */}
+              <div style={{ textAlign: 'right', fontSize: '8.5pt', marginBottom: '4px' }}>
+                <Sel current={plan.planType} value="初回" />・
+                <Sel current={plan.planType} value="紹介" />・
+                <Sel current={plan.planType} value="継続" />
+                <span style={{ marginLeft: '16px' }}>
+                  <Sel current={plan.certificationStatus} value="認定済" />・
+                  <Sel current={plan.certificationStatus} value="申請中" />
+                </span>
+              </div>
+
+              {/* === 第1表 本体テーブル === */}
+              <table className="f-table" style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+                <colgroup>
+                  <col style={{ width: '16%' }} />
+                  <col style={{ width: '15%' }} />
+                  <col style={{ width: '12%' }} />
+                  <col style={{ width: '23%' }} />
+                  <col style={{ width: '5%' }} />
+                  <col style={{ width: '29%' }} />
+                </colgroup>
                 <tbody>
 
-                  {/* 保険者番号 / 被保険者番号 */}
+                  {/* 行1: 利用者名（フリガナ）/ 生年月日・性別 / 住所 */}
                   <tr>
-                    <th style={{ width: '18%', border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>保険者番号</th>
-                    <td style={{ width: '20%', border: '1px solid #333', padding: '4px 6px' }}>{user.insurerNumber ?? ''}</td>
-                    <th style={{ width: '18%', border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>被保険者番号</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>{user.insuredNumber ?? ''}</td>
-                  </tr>
-
-                  {/* 利用者名 / 生年月日 */}
-                  <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>利用者名</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>{user.name}　様</td>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>生年月日</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>
-                      {formatJaDate(user.birthDate)}　{user.gender}
+                    <th style={TH}>利用者名</th>
+                    <td style={TD}>
+                      {user.kana && <div style={{ fontSize: '7pt', color: '#555', marginBottom: '1px' }}>{user.kana}</div>}
+                      {user.name}　殿
                     </td>
+                    <th style={TH}>生年月日</th>
+                    <td style={TD}>{formatJaDate(user.birthDate)}　{user.gender}</td>
+                    <th style={TH}>住所</th>
+                    <td style={TD}>{user.address}</td>
                   </tr>
 
-                  {/* 住所 */}
+                  {/* 行2: 居宅サービス計画作成者氏名 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>住所</th>
-                    <td colSpan={3} style={{ border: '1px solid #333', padding: '4px 6px' }}>{user.address}</td>
+                    <th style={TH}>居宅サービス計画作成者氏名</th>
+                    <td colSpan={5} style={TD}>{careManagerInfo?.name ?? ''}</td>
                   </tr>
 
-                  {/* 居宅サービス計画作成者氏名 */}
+                  {/* 行3: 居宅介護支援事業者・事業所名及び所在地 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>居宅サービス計画作成者氏名</th>
-                    <td colSpan={3} style={{ border: '1px solid #333', padding: '4px 6px' }}>{careManagerInfo?.name ?? ''}</td>
+                    <th style={{ ...TH, fontSize: '8pt' }}>
+                      居宅介護支援事業者・<br />事業所名及び所在地
+                    </th>
+                    <td colSpan={5} style={TD}>{careManagerInfo?.office ?? ''}</td>
                   </tr>
 
-                  {/* 居宅介護支援事業者・事業所名及び所在地 */}
+                  {/* 行4: 居宅サービス計画作成（変更）日 / 初回居宅サービス計画作成日 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'normal', wordBreak: 'keep-all' }}>居宅介護支援事業者・<br />事業所名及び所在地</th>
-                    <td colSpan={3} style={{ border: '1px solid #333', padding: '4px 6px' }}>{careManagerInfo?.office ?? ''}</td>
+                    <th style={{ ...TH, fontSize: '8pt' }}>
+                      居宅サービス計画作成（変更）日
+                    </th>
+                    <td style={{ ...TD, whiteSpace: 'nowrap' }}>{formatJaDate(plan.planCreationDate ?? plan.draftDate)}</td>
+                    <th style={{ ...TH, fontSize: '7pt' }}>
+                      初回居宅サービス<br />計画作成日
+                    </th>
+                    <td colSpan={3} style={{ ...TD, whiteSpace: 'nowrap' }}>{formatJaDate(plan.firstPlanDate)}</td>
                   </tr>
 
-                  {/* 計画作成（変更）日 / 初回計画作成日 */}
+                  {/* 行5: 認定日 / 認定の有効期間 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'normal', wordBreak: 'keep-all' }}>居宅サービス計画作成<br />（変更）日</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>
-                      {formatJaDate(plan.planCreationDate ?? plan.draftDate)}
-                    </td>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'normal', wordBreak: 'keep-all' }}>初回居宅サービス<br />計画作成日</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>
-                      {formatJaDate(plan.firstPlanDate)}
-                    </td>
-                  </tr>
-
-                  {/* 初回・紹介・継続 / 認定済・申請中 */}
-                  <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>初回・紹介・継続</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>
-                      <SelectOption value={plan.planType} options={['初回', '紹介', '継続']} />
-                      <span style={{ fontSize: '7.5pt', color: '#666' }}>（いずれかに○）</span>
-                    </td>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>認定済・申請中</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>
-                      <SelectOption value={plan.certificationStatus} options={['認定済', '申請中']} />
-                      <span style={{ fontSize: '7.5pt', color: '#666' }}>（いずれかに○）</span>
-                    </td>
-                  </tr>
-
-                  {/* 要介護状態区分 / 認定の有効期間 */}
-                  <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>要介護状態区分</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>{user.careLevel}</td>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>認定の有効期間</th>
-                    <td style={{ border: '1px solid #333', padding: '4px 6px' }}>
+                    <th style={TH}>認定日</th>
+                    <td style={{ ...TD, whiteSpace: 'nowrap' }}>{formatJaDate(user.certificationDate)}</td>
+                    <th style={TH}>認定の有効期間</th>
+                    <td colSpan={3} style={TD}>
                       {formatJaDate(user.certificationDate)}　〜　{formatJaDate(user.certificationExpiry)}
                     </td>
                   </tr>
 
-                  {/* 利用者及び家族の生活に関する意向を踏まえた課題分析の結果 */}
+                  {/* 行6: 要介護状態区分（要介護1〜5 選択を○囲み） */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'normal', wordBreak: 'keep-all', fontSize: '8.5pt' }}>
-                      利用者及び家族の生活に関する意向を踏まえた課題分析の結果
-                    </th>
-                    <td colSpan={3} style={{ border: '1px solid #333', padding: '6px', minHeight: '64px', verticalAlign: 'top' }}>
-                      {plan.userIntention && <div>本人：{plan.userIntention}</div>}
-                      {plan.familyIntention && <div style={{ marginTop: '4px' }}>家族等：{plan.familyIntention}</div>}
+                    <th style={TH}>要介護状態区分</th>
+                    <td colSpan={5} style={TD}>
+                      {CARE_LEVELS.map((level, i) => (
+                        <React.Fragment key={level}>
+                          {i > 0 && '　'}
+                          <span
+                            style={currentCareLevel === level
+                              ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' }
+                              : {}}
+                          >
+                            {level}
+                          </span>
+                        </React.Fragment>
+                      ))}
                     </td>
                   </tr>
 
-                  {/* 認定審査会の意見及びサービスの種類の指定 */}
+                  {/* 行7: 利用者及び家族の生活に対する意向を踏まえた課題分析の結果 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'normal', wordBreak: 'keep-all', fontSize: '8.5pt' }}>
-                      認定審査会の意見及びサービスの種類の指定
+                    <th style={{ ...TH, whiteSpace: 'normal', wordBreak: 'keep-all', fontSize: '8pt' }}>
+                      利用者及び家族の生活に対する意向を踏まえた課題分析の結果
                     </th>
-                    <td colSpan={3} style={{ border: '1px solid #333', padding: '6px', minHeight: '36px', verticalAlign: 'top' }}>
+                    <td colSpan={5} style={{ ...TD, minHeight: '64px' }}>
+                      {plan.userIntention && <div>本人：{plan.userIntention}</div>}
+                      {plan.familyIntention && <div style={{ marginTop: '3px' }}>家族等：{plan.familyIntention}</div>}
+                    </td>
+                  </tr>
+
+                  {/* 行8: 介護認定審査会の意見及びサービスの種類の指定 */}
+                  <tr>
+                    <th style={{ ...TH, whiteSpace: 'normal', wordBreak: 'keep-all', fontSize: '8pt' }}>
+                      介護認定審査会の意見及びサービスの種類の指定
+                    </th>
+                    <td colSpan={5} style={{ ...TD, minHeight: '36px' }}>
                       {plan.reviewOpinion ?? 'なし'}
                     </td>
                   </tr>
 
-                  {/* 総合的な援助の方針 */}
+                  {/* 行9: 総合的な援助の方針 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'nowrap' }}>総合的な援助の方針</th>
-                    <td colSpan={3} style={{ border: '1px solid #333', padding: '6px', minHeight: '80px', verticalAlign: 'top' }}>
+                    <th style={TH}>総合的な援助の方針</th>
+                    <td colSpan={5} style={{ ...TD, minHeight: '72px' }}>
                       {plan.totalDirectionPolicy ?? ''}
                     </td>
                   </tr>
 
-                  {/* 生活援助中心型の算定理由 */}
+                  {/* 行10: 生活援助中心型の算定理由 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '4px 6px', background: '#f0f0f0', fontWeight: 'bold', whiteSpace: 'normal', wordBreak: 'keep-all', fontSize: '8.5pt' }}>
+                    <th style={{ ...TH, whiteSpace: 'normal', wordBreak: 'keep-all', fontSize: '8pt' }}>
                       生活援助中心型の算定理由
                     </th>
-                    <td colSpan={3} style={{ border: '1px solid #333', padding: '4px 6px' }}>
-                      <span style={plan.lifeAssistanceReason === '1' ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' } : {}}>
-                        ①一人暮らし
+                    <td colSpan={5} style={TD}>
+                      <span
+                        style={plan.lifeAssistanceReason === '1'
+                          ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' }
+                          : {}}
+                      >
+                        １．一人暮らし
                       </span>
-
-                      <span style={plan.lifeAssistanceReason === '2' ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' } : {}}>
-                        ②家族等が障害・疾病等
+                      {'　'}
+                      <span
+                        style={plan.lifeAssistanceReason === '2'
+                          ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' }
+                          : {}}
+                      >
+                        ２．家族等が障害、疾病等
                       </span>
-
-                      <span style={plan.lifeAssistanceReason === '3' ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' } : {}}>
-                        ③その他（{plan.lifeAssistanceReason === '3' ? (plan.lifeAssistanceReasonOther ?? '') : '　　　　　'}）
+                      {'　'}
+                      <span
+                        style={plan.lifeAssistanceReason === '3'
+                          ? { display: 'inline-block', border: '1.5px solid #333', borderRadius: '9999px', padding: '0 4px', fontWeight: 'bold' }
+                          : {}}
+                      >
+                        ３．その他（{plan.lifeAssistanceReason === '3' ? (plan.lifeAssistanceReasonOther ?? '') : '　　　　　　　　'}）
                       </span>
                     </td>
                   </tr>
@@ -468,57 +463,61 @@ export const PrintPreview: React.FC<Props> = ({ isOpen, onClose, user, plan, ass
                 </tbody>
               </table>
 
-              <div style={{ textAlign: 'right', fontSize: '7pt', color: '#aaa', marginTop: '6px' }}>
+              <div style={{ textAlign: 'right', fontSize: '7pt', color: '#aaa', marginTop: '4px' }}>
                 ケアマネのミカタ 出力
               </div>
             </div>
 
-            {/* ========== 第2表: 居宅サービス計画書（2） ========== */}
+            {/* ══════════════════════════════════════════
+                第2表: 居宅サービス計画書（２）
+                ══════════════════════════════════════════ */}
             <div
-              className="sheet2 bg-white shadow-md mx-auto p-6"
-              style={{ maxWidth: '297mm', fontFamily: '"Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif', fontSize: '9pt' }}
+              className="sheet2 bg-white shadow-md mx-auto p-4"
+              style={{ maxWidth: '297mm', fontFamily: '"Hiragino Kaku Gothic ProN","Hiragino Sans",Meiryo,sans-serif', fontSize: '9pt' }}
             >
-              {/* タイトルエリア */}
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '4px' }}>
-                <div style={{ fontSize: '13pt', fontWeight: 'bold' }}>居宅サービス計画書（２）</div>
-                <div style={{ fontSize: '7.5pt', textAlign: 'right' }}>
-                  作成年月日　{planCreationDate}<br />第２表
+              {/* === 第2表ヘッダーエリア === */}
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2px' }}>
+                <div style={{ border: '1px solid #333', padding: '1px 6px', fontSize: '9pt', fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+                  第２表
+                </div>
+                <div style={{ fontSize: '13pt', fontWeight: 'bold', textAlign: 'center', flex: 1 }}>
+                  居宅サービス計画書（２）
+                </div>
+                <div style={{ textAlign: 'right', fontSize: '8pt', whiteSpace: 'nowrap', minWidth: '140px' }}>
+                  作成年月日　{planDate}
                 </div>
               </div>
-
-              {/* 利用者名 / ケアマネ名ヘッダー */}
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '6px', fontSize: '9pt' }}>
-                <div>利用者名　<strong>{user.name}</strong>　様</div>
-                <div>居宅サービス計画作成者氏名　{careManagerInfo?.name ?? ''}</div>
+              <div style={{ fontSize: '9pt', marginBottom: '4px' }}>
+                利用者名　<strong>{user.name}</strong>　殿
               </div>
 
-              {/* ニーズ・目標・援助内容テーブル */}
-              <table className="needs-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+              {/* === 第2表 ニーズ・目標・援助内容テーブル（公式様式準拠） === */}
+              <table className="n-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
                 <thead>
+                  {/* 1段目ヘッダー: ニーズ | 目標(colSpan=4) | 援助内容(colSpan=6) */}
                   <tr>
-                    <th rowSpan={2} style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '20%', verticalAlign: 'middle' }}>
+                    <th rowSpan={2} style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '16%', verticalAlign: 'middle', fontSize: '7.5pt' }}>
                       生活全般の解決すべき課題（ニーズ）
                     </th>
-                    <th colSpan={2} style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', textAlign: 'center' }}>
+                    <th colSpan={4} style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', textAlign: 'center', fontSize: '7.5pt' }}>
                       目標
                     </th>
-                    <th colSpan={2} style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', textAlign: 'center' }}>
-                      目標
-                    </th>
-                    <th colSpan={5} style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', textAlign: 'center' }}>
+                    <th colSpan={6} style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', textAlign: 'center', fontSize: '7.5pt' }}>
                       援助内容
                     </th>
                   </tr>
+                  {/* 2段目ヘッダー: 長期目標 | 期間 | 短期目標 | 期間 | サービス内容 | ※1 | サービス種別 | ※２ | 頻度 | 期間 */}
                   <tr>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '12%' }}>（長期目標）</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '8%' }}>期間</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '11%' }}>（短期目標）</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '7%' }}>期間</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '14%' }}>サービス内容</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '4%' }}>※1</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '10%' }}>※2（事業所）</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '7%' }}>頻度</th>
-                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '7%' }}>期間</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '14%', fontSize: '7.5pt' }}>長期目標</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '8%', fontSize: '7.5pt' }}>期間</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '12%', fontSize: '7.5pt' }}>短期目標</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '7%', fontSize: '7.5pt' }}>期間</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '13%', fontSize: '7.5pt' }}>サービス内容</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '3%', fontSize: '7.5pt' }}>※１</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '10%', fontSize: '7.5pt' }}>サービス種別</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '7%', fontSize: '7.5pt' }}>※２</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '5%', fontSize: '7.5pt' }}>頻度</th>
+                    <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '5%', fontSize: '7.5pt' }}>期間</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -527,70 +526,75 @@ export const PrintPreview: React.FC<Props> = ({ isOpen, onClose, user, plan, ass
               </table>
 
               {/* 注釈 */}
-              <div style={{ fontSize: '7.5pt', color: '#444', marginTop: '4px' }}>
-                ※1　保険給付の対象となるサービスについて記入する場合には、○印で囲む。<br />
-                ※2　当該サービス内容に対応したサービス種別及び当該サービスを担当する者等を記入する。
+              <div style={{ fontSize: '7pt', color: '#444', marginTop: '3px' }}>
+                ※１　「保険給付の対象となるかどうかの区分」について、保険給付対象内サービスについては○印を付す。<br />
+                ※２　「当該サービス提供を行う事業所」について記入する。
               </div>
 
-              <div style={{ textAlign: 'right', fontSize: '7pt', color: '#aaa', marginTop: '6px' }}>
+              <div style={{ textAlign: 'right', fontSize: '7pt', color: '#aaa', marginTop: '4px' }}>
                 ケアマネのミカタ 出力
               </div>
             </div>
 
-            {/* ========== 第3表: 週間サービス計画表 ========== */}
+            {/* ══════════════════════════════════════════
+                第3表: 週間サービス計画表
+                ══════════════════════════════════════════ */}
             {plan.weeklySchedule && (plan.weeklySchedule.entries.length > 0 || plan.weeklySchedule.mainActivities || plan.weeklySchedule.weeklyNote) && (
               <div
-                className="sheet3 bg-white shadow-md mx-auto p-6"
-                style={{ maxWidth: '297mm', fontFamily: '"Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif', fontSize: '9pt' }}
+                className="sheet3 bg-white shadow-md mx-auto p-4"
+                style={{ maxWidth: '297mm', fontFamily: '"Hiragino Kaku Gothic ProN","Hiragino Sans",Meiryo,sans-serif', fontSize: '9pt' }}
               >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '4px' }}>
-                  <div style={{ fontSize: '13pt', fontWeight: 'bold' }}>週間サービス計画表</div>
-                  <div style={{ fontSize: '7.5pt', textAlign: 'right' }}>第３表</div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2px' }}>
+                  <div style={{ border: '1px solid #333', padding: '1px 6px', fontSize: '9pt', fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+                    第３表
+                  </div>
+                  <div style={{ fontSize: '13pt', fontWeight: 'bold', textAlign: 'center', flex: 1 }}>
+                    週間サービス計画表
+                  </div>
+                  <div style={{ textAlign: 'right', fontSize: '8pt', whiteSpace: 'nowrap', minWidth: '140px' }}>
+                    作成年月日　{planDate}
+                  </div>
                 </div>
-
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '6px', fontSize: '9pt' }}>
-                  <div>利用者名　<strong>{user.name}</strong>　様</div>
-                  <div>居宅サービス計画作成者氏名　{careManagerInfo?.name ?? ''}</div>
+                <div style={{ fontSize: '9pt', marginBottom: '4px' }}>
+                  利用者名　<strong>{user.name}</strong>　殿
                 </div>
 
                 {plan.weeklySchedule.mainActivities && (
-                  <div style={{ marginBottom: '8px' }}>
-                    <div style={{ fontWeight: 'bold', fontSize: '9pt', marginBottom: '2px' }}>主な日常生活上の活動</div>
-                    <div style={{ border: '1px solid #333', padding: '6px', fontSize: '9pt' }}>
+                  <div style={{ marginBottom: '6px' }}>
+                    <div style={{ fontWeight: 'bold', fontSize: '8.5pt', marginBottom: '2px' }}>主な日常生活上の活動</div>
+                    <div style={{ border: '1px solid #333', padding: '4px 6px', fontSize: '8.5pt' }}>
                       {plan.weeklySchedule.mainActivities}
                     </div>
                   </div>
                 )}
 
                 {plan.weeklySchedule.entries.length > 0 && (
-                  <table className="weekly-table" style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '8px' }}>
+                  <table className="w-table" style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '6px' }}>
                     <thead>
                       <tr>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '12%' }}>サービス種別</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '15%' }}>事業所名</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '20%' }}>サービス内容</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '6%', textAlign: 'center' }}>月</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '6%', textAlign: 'center' }}>火</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '6%', textAlign: 'center' }}>水</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '6%', textAlign: 'center' }}>木</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '6%', textAlign: 'center' }}>金</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '6%', textAlign: 'center' }}>土</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '6%', textAlign: 'center' }}>日</th>
-                        <th style={{ border: '1px solid #333', padding: '3px 4px', background: '#f0f0f0', width: '11%' }}>時間</th>
+                        <th style={{ border: '1px solid #333', padding: '2px 4px', background: '#f0f0f0', width: '12%' }}>サービス種別</th>
+                        <th style={{ border: '1px solid #333', padding: '2px 4px', background: '#f0f0f0', width: '15%' }}>事業所名</th>
+                        <th style={{ border: '1px solid #333', padding: '2px 4px', background: '#f0f0f0', width: '20%' }}>サービス内容</th>
+                        {(['月', '火', '水', '木', '金', '土', '日'] as const).map(d => (
+                          <th key={d} style={{ border: '1px solid #333', padding: '2px 4px', background: '#f0f0f0', width: '5%', textAlign: 'center' }}>{d}</th>
+                        ))}
+                        <th style={{ border: '1px solid #333', padding: '2px 4px', background: '#f0f0f0', width: '11%' }}>時間</th>
                       </tr>
                     </thead>
                     <tbody>
                       {plan.weeklySchedule.entries.map((entry) => (
                         <tr key={entry.id}>
-                          <td style={{ border: '1px solid #333', padding: '3px 4px' }}>{entry.serviceType}</td>
-                          <td style={{ border: '1px solid #333', padding: '3px 4px' }}>{entry.provider}</td>
-                          <td style={{ border: '1px solid #333', padding: '3px 4px' }}>{entry.content}{entry.frequency ? `（${entry.frequency}）` : ''}</td>
+                          <td style={{ border: '1px solid #333', padding: '2px 4px' }}>{entry.serviceType}</td>
+                          <td style={{ border: '1px solid #333', padding: '2px 4px' }}>{entry.provider}</td>
+                          <td style={{ border: '1px solid #333', padding: '2px 4px' }}>
+                            {entry.content}{entry.frequency ? `（${entry.frequency}）` : ''}
+                          </td>
                           {(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const).map(d => (
-                            <td key={d} style={{ border: '1px solid #333', padding: '3px 4px', textAlign: 'center', fontWeight: 'bold' }}>
+                            <td key={d} style={{ border: '1px solid #333', padding: '2px 4px', textAlign: 'center', fontWeight: 'bold' }}>
                               {entry.days.includes(d) ? '●' : ''}
                             </td>
                           ))}
-                          <td style={{ border: '1px solid #333', padding: '3px 4px' }}>
+                          <td style={{ border: '1px solid #333', padding: '2px 4px' }}>
                             {entry.startTime && entry.endTime ? `${entry.startTime}〜${entry.endTime}` : entry.startTime || ''}
                           </td>
                         </tr>
@@ -601,14 +605,14 @@ export const PrintPreview: React.FC<Props> = ({ isOpen, onClose, user, plan, ass
 
                 {plan.weeklySchedule.weeklyNote && (
                   <div>
-                    <div style={{ fontWeight: 'bold', fontSize: '9pt', marginBottom: '2px' }}>週単位以外のサービス</div>
-                    <div style={{ border: '1px solid #333', padding: '6px', fontSize: '9pt' }}>
+                    <div style={{ fontWeight: 'bold', fontSize: '8.5pt', marginBottom: '2px' }}>週単位以外のサービス</div>
+                    <div style={{ border: '1px solid #333', padding: '4px 6px', fontSize: '8.5pt' }}>
                       {plan.weeklySchedule.weeklyNote}
                     </div>
                   </div>
                 )}
 
-                <div style={{ textAlign: 'right', fontSize: '7pt', color: '#aaa', marginTop: '6px' }}>
+                <div style={{ textAlign: 'right', fontSize: '7pt', color: '#aaa', marginTop: '4px' }}>
                   ケアマネのミカタ 出力
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- `table-layout: fixed` を追加し、colgroup の % 指定が正確に機能するよう修正（根本原因）
- colgroup の列幅を調整して全セルのオーバーフローを解消
  - col1: 14% → 16%
  - col2: 16% → 15%
  - col3: 11% → 12%（「初回居宅サービス」8文字が2行に収まるよう）
- 行3・行4の TH から不要な `word-break: keep-all` を削除
- 「初回居宅サービス計画作成日」ヘッダーのフォントを 8pt → 7pt に変更
- Playwright の `scrollWidth / offsetWidth` 計測で全セルのオーバーフローなしを確認済み

## 確認済みレイアウト

| 項目 | 結果 |
|------|------|
| 生年月日（昭和〜年〜月〜日 男/女） | 1行 ✅ |
| 住所 | 1行 ✅ |
| 初回居宅サービス計画作成日ヘッダー | 2行（3行→2行に改善）✅ |
| 全セル scrollWidth < offsetWidth | ✅ |
| 第2表 テーブル構造（10列） | ✅ |

## Test plan

- [x] Playwright スクリーンショットで第1表レイアウトを目視確認
- [x] `browser_evaluate` で全セルの scrollWidth / offsetWidth を計測
- [x] 第2表の構造・オーバーフロー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)