### PR TITLE
fix: apple-mobile-web-app-capable 非推奨メタタグを更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#3B82F6" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="ケアマネのミカタ" />
     <title>ケアマネのミカタ 2025 - Care Manager AI Copilot</title>


### PR DESCRIPTION
## Summary
- 非推奨の `apple-mobile-web-app-capable` を `mobile-web-app-capable` に置き換え
- コンソールのdeprecation警告を解消

## Test plan
- [ ] コンソールに `apple-mobile-web-app-capable is deprecated` 警告が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)