### PR TITLE
chore(ci): GitHub Actions を最新メジャー版へ更新（Node.js 24 対応）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,17 +18,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'npm'
@@ -63,13 +63,13 @@ jobs:
 
     steps:
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Cleanup old container images
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'npm'
 
       - name: Setup Java (Firebase Emulator)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-test-results
           path: |

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'npm'
 
       - name: Setup Java (Firebase Emulator)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:live": "vitest run tests/assessment/extraction.live.test.ts --reporter=verbose",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:rules": "vitest run tests/rules --reporter=verbose",
+    "test:rules": "vitest run --config vitest.rules.config.ts --reporter=verbose",
     "test:e2e:demo": "firebase emulators:exec --only auth,firestore --project caremanager-ai-copilot-486212 \"npx tsx scripts/seed.ts test-user-uid --emulator && npx playwright test\"",
     "test:demo": "firebase emulators:exec --only auth,firestore --project caremanager-ai-copilot-486212 \"npx tsx scripts/seed.ts test-user-uid --emulator && vitest run && npx playwright test\""
   },

--- a/vitest.rules.config.ts
+++ b/vitest.rules.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/rules/**/*.test.ts'],
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary

- 2026-09-16 の **Node.js 20 ランタイム削除**（GitHub Actions runners）に備え、JavaScript actions を最新メジャー版へ更新
- 上記 CI 失敗で発覚した既存の rules テスト構成バグも併せて修正

## 更新内容

### 1) Actions の最新メジャー版への更新

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | **v6** |
| actions/setup-node | v4 | **v6** |
| actions/setup-java | v4 | **v5** |
| actions/upload-artifact | v4 | **v7** |
| google-github-actions/auth | v2 | **v3** |
| google-github-actions/setup-gcloud | v2 | **v3** |

### 2) rules テスト構成の修正（既存バグ）

- 旧: `vitest.config.ts` の `exclude: tests/rules/**` が CLI filter `tests/rules` より優先され `No test files found` で exit 1
- 原因: vitest v3 → v4 で exclude の優先順位が上がった挙動変更（直近成功は 2026-02-22 の vitest v3 時代）
- 新: 専用設定 `vitest.rules.config.ts` を新設し、`package.json` の `test:rules` から参照

## 据え置き

- `setup-node` の `node-version: 20`: Cloud Functions ランタイム（`functions/package.json` の `engines.node: 20`）と整合させるため据え置き
- Functions ランタイムを Node 22 に上げるかは別タスク（Firebase 側の互換確認・テスト要）

## 互換性確認

- **upload-artifact v5/v6/v7**: 実質「Node 24 ランタイム対応」のためのメジャー更新で挙動 breaking なし
- **checkout v6.0.0**: credential を別ファイルに persist する変更あり。当 repo の workflow は単一 checkout なので影響なし
- **auth@v3 / setup-gcloud@v3**: 削除された input (`retries`, `backoff`, `skip_tool_cache` 等) は当 workflow 未使用

## 動作確認

- ローカル rules テスト: `firebase emulators:exec --only firestore "npm run test:rules"` → **Test Files 1 passed / Tests 51 passed**
- code-reviewer agent レビュー: Critical 0 / Important 0（マージ可能判定）

## Test plan

- [ ] 本 PR の `E2E Tests` CI が success（Playwright 24 件パス）
- [ ] 本 PR の `Firestore Rules Tests` CI が success（rules 修正後）
- [ ] マージ後 `Deploy to Firebase` CI が success
- [ ] マージ後の Cloud Functions デプロイで Node 24 ランタイム警告が消えていること（次セッションで確認）

## 参考

- [Deprecation of Node 20 on GitHub Actions runners (2025-09-19)](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- 期限: 2026-06-02 デフォルト変更 / 2026-09-16 削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)